### PR TITLE
feat: DiariesコントローラーとPundit認可を実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,17 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  include Pundit::Authorization
 
-  # Changes to the importmap will invalidate the etag for HTML responses
+  allow_browser versions: :modern
   stale_when_importmap_changes
+
+  before_action :authenticate_user!
+
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  private
+
+  def user_not_authorized
+    flash[:alert] = "この操作は許可されていません。"
+    redirect_back fallback_location: root_path
+  end
 end

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,0 +1,57 @@
+class DiariesController < ApplicationController
+  before_action :set_diary, only: %i[show edit update destroy]
+
+  def index
+    @diaries = policy_scope(Diary).order(recorded_on: :desc)
+    # TODO: Issue #5 完了後、WeatherService で天気・雨判定を取得
+  end
+
+  def show
+    authorize @diary
+  end
+
+  def new
+    @diary = current_user.diaries.build
+    authorize @diary
+  end
+
+  def create
+    @diary = current_user.diaries.build(diary_params)
+    authorize @diary
+    if @diary.save
+      # TODO: Issue #5 完了後、@diary.attach_weather!（API失敗時も日記は保存済み）
+      redirect_to @diary, notice: "日記を作成しました。"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    authorize @diary
+  end
+
+  def update
+    authorize @diary
+    if @diary.update(diary_params)
+      redirect_to @diary, notice: "日記を更新しました。"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    authorize @diary
+    @diary.destroy
+    redirect_to diaries_path, notice: "日記を削除しました。"
+  end
+
+  private
+
+  def set_diary
+    @diary = Diary.find(params[:id])
+  end
+
+  def diary_params
+    params.require(:diary).permit(:title, :body, :recorded_on, :mood)
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NoMethodError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/diary_policy.rb
+++ b/app/policies/diary_policy.rb
@@ -1,0 +1,21 @@
+class DiaryPolicy < ApplicationPolicy
+  def index?   = true
+  def show?    = owner?
+  def new?     = create?
+  def create?  = true
+  def edit?    = update?
+  def update?  = owner?
+  def destroy? = owner?
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      scope.where(user: user)
+    end
+  end
+
+  private
+
+  def owner?
+    record.user_id == user.id
+  end
+end

--- a/app/views/diaries/_form.html.haml
+++ b/app/views/diaries/_form.html.haml
@@ -1,0 +1,6 @@
+= simple_form_for diary do |f|
+  = f.input :title
+  = f.input :body
+  = f.input :recorded_on
+  = f.input :mood
+  = f.submit

--- a/app/views/diaries/edit.html.haml
+++ b/app/views/diaries/edit.html.haml
@@ -1,0 +1,3 @@
+%h1 日記を編集
+
+= render "form", diary: @diary

--- a/app/views/diaries/index.html.haml
+++ b/app/views/diaries/index.html.haml
@@ -1,0 +1,6 @@
+%h1 日記一覧
+
+- @diaries.each do |diary|
+  %div
+    = link_to diary.title, diary_path(diary)
+    = diary.recorded_on

--- a/app/views/diaries/new.html.haml
+++ b/app/views/diaries/new.html.haml
@@ -1,0 +1,3 @@
+%h1 日記を作成
+
+= render "form", diary: @diary

--- a/app/views/diaries/show.html.haml
+++ b/app/views/diaries/show.html.haml
@@ -1,0 +1,8 @@
+%h1= @diary.title
+
+%p= @diary.body
+%p= @diary.recorded_on
+%p= @diary.mood
+
+= link_to "編集", edit_diary_path(@diary)
+= link_to "一覧へ", diaries_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  resources :diaries
+  root "diaries#index"
   get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-
-  # Defines the root path route ("/")
-  # root "posts#index"
 end

--- a/spec/policies/diary_policy_spec.rb
+++ b/spec/policies/diary_policy_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe DiaryPolicy do
+  let(:user)  { create(:user) }
+  let(:other) { create(:user) }
+  let(:diary) { create(:diary, user: user) }
+
+  def policy(record, acting_as: user)
+    described_class.new(acting_as, record)
+  end
+
+  describe "index?" do
+    it "ログイン済みユーザーなら許可する" do
+      expect(policy(Diary).index?).to be true
+    end
+  end
+
+  describe "new? / create?" do
+    it "ログイン済みユーザーなら許可する" do
+      expect(policy(Diary).new?).to be true
+      expect(policy(Diary).create?).to be true
+    end
+  end
+
+  describe "show?" do
+    it "diaryの所有者なら許可する" do
+      expect(policy(diary).show?).to be true
+    end
+
+    it "diaryの所有者でなければ拒否する" do
+      expect(policy(diary, acting_as: other).show?).to be false
+    end
+  end
+
+  describe "edit? / update?" do
+    it "diaryの所有者なら許可する" do
+      expect(policy(diary).edit?).to be true
+      expect(policy(diary).update?).to be true
+    end
+
+    it "diaryの所有者でなければ拒否する" do
+      expect(policy(diary, acting_as: other).edit?).to be false
+      expect(policy(diary, acting_as: other).update?).to be false
+    end
+  end
+
+  describe "destroy?" do
+    it "diaryの所有者なら許可する" do
+      expect(policy(diary).destroy?).to be true
+    end
+
+    it "diaryの所有者でなければ拒否する" do
+      expect(policy(diary, acting_as: other).destroy?).to be false
+    end
+  end
+
+  describe DiaryPolicy::Scope do
+    it "自分のdiaryのみを返す" do
+      own_diary   = create(:diary, user: user)
+      other_diary = create(:diary, user: other)
+      resolved = described_class.new(user, Diary).resolve
+      expect(resolved).to include(own_diary)
+      expect(resolved).not_to include(other_diary)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,7 +63,7 @@ RSpec.configure do |config|
   # behaviour is considered legacy and will be removed in a future version.
   #
   # To enable this behaviour uncomment the line below.
-  # config.infer_spec_type_from_file_location!
+  config.infer_spec_type_from_file_location!
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!

--- a/spec/requests/diaries_spec.rb
+++ b/spec/requests/diaries_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe "Diaries", type: :request do
+  let(:user) { create(:user) }
+
+  describe "GET /diaries" do
+    context "未ログインの場合" do
+      it "サインインページへリダイレクトする" do
+        get diaries_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "ログイン済みの場合" do
+      before { sign_in user }
+
+      it "200 OKを返す" do
+        get diaries_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "GET /diaries/:id" do
+    let!(:diary) { create(:diary, user: user) }
+
+    before { sign_in user }
+
+    it "自分のdiaryにアクセスできる" do
+      get diary_path(diary)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /diaries" do
+    before { sign_in user }
+
+    let(:valid_params) do
+      { diary: { title: "今日の日記", body: "晴れだった", recorded_on: Date.today, mood: 3 } }
+    end
+
+    it "ログインユーザーに紐づくdiaryを作成する" do
+      expect {
+        post diaries_path, params: valid_params
+      }.to change(user.diaries, :count).by(1)
+    end
+
+    it "作成したdiaryの詳細ページへリダイレクトする" do
+      post diaries_path, params: valid_params
+      expect(response).to redirect_to(diary_path(Diary.last))
+    end
+  end
+
+  describe "GET /diaries/:id/edit" do
+    let!(:diary) { create(:diary, user: user) }
+
+    before { sign_in user }
+
+    it "自分のdiaryの編集ページを表示する" do
+      get edit_diary_path(diary)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "PATCH /diaries/:id" do
+    let!(:diary) { create(:diary, user: user) }
+
+    before { sign_in user }
+
+    it "自分のdiaryを更新してdiaryの詳細ページへリダイレクトする" do
+      patch diary_path(diary), params: { diary: { title: "更新後タイトル" } }
+      expect(response).to redirect_to(diary_path(diary))
+      expect(diary.reload.title).to eq "更新後タイトル"
+    end
+  end
+
+  describe "DELETE /diaries/:id" do
+    let!(:diary) { create(:diary, user: user) }
+
+    before { sign_in user }
+
+    it "自分のdiaryを削除してdiaryの一覧ページへリダイレクトする" do
+      expect {
+        delete diary_path(diary)
+      }.to change(user.diaries, :count).by(-1)
+      expect(response).to redirect_to(diaries_path)
+    end
+  end
+end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include Devise::Test::IntegrationHelpers, type: :request
+end


### PR DESCRIPTION
## Summary

- `DiariesController` に CRUD アクションを追加し、`policy_scope` / `authorize` で Pundit 認可を適用
- `DiaryPolicy` を作成（所有者のみ編集・削除可、`Scope` で自分の日記のみ取得）
- `ApplicationController` に `Pundit::Authorization` インクルードと `NotAuthorizedError` ハンドリングを追加

## Test plan

- [ ] `bundle exec rspec spec/requests/diaries_spec.rb` — リクエストスペックが全件パス
- [ ] `bundle exec rspec spec/policies/diary_policy_spec.rb` — ポリシースペックが全件パス
- [ ] 未ログイン時にアクセスするとログインページへリダイレクトされること
- [ ] 他ユーザーの日記を編集・削除しようとすると `NotAuthorizedError` でリダイレクトされること

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now create, view, edit, and delete diary entries with title, body, date, and mood fields
  * Added diary list view to browse all entries
  * Authorization ensures users can only access their own diaries
  * Login required to use diary functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->