### PR TITLE
feat: Haml ビューに Bootstrap 5 を適用し雨判定 UI を実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,11 @@
 # Omakase Ruby styling for Rails
 inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
+AllCops:
+  Exclude:
+    - "config/initializers/simple_form_bootstrap.rb"
+    - "config/initializers/simple_form.rb"
+
 # Overwrite or add rules to create your own house style
 #
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,11 +7,17 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   private
 
   def user_not_authorized
     flash[:alert] = "この操作は許可されていません。"
     redirect_back fallback_location: root_path
+  end
+
+  def record_not_found
+    flash[:alert] = "指定されたリソースは見つかりません。"
+    redirect_to root_path
   end
 end

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -2,8 +2,13 @@ class DiariesController < ApplicationController
   before_action :set_diary, only: %i[show edit update destroy]
 
   def index
-    @diaries = policy_scope(Diary).order(recorded_on: :desc)
-    # TODO: Issue #5 完了後、WeatherService で天気・雨判定を取得
+    scope = policy_scope(Diary)
+    @diaries      = scope.includes(:weather_record).order(recorded_on: :desc).page(params[:page])
+    @total_count  = scope.count
+    @yearly_count = scope.where(recorded_on: Date.current.all_year).count
+
+    weather    = WeatherService.new.fetch
+    @rainy_now = weather.present? && WeatherRecord.rainy_main?(weather[:weather_main])
   end
 
   def show
@@ -48,7 +53,7 @@ class DiariesController < ApplicationController
   private
 
   def set_diary
-    @diary = Diary.find(params[:id])
+    @diary = policy_scope(Diary).find(params[:id])
   end
 
   def diary_params

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -8,7 +8,7 @@ class DiariesController < ApplicationController
     @yearly_count = scope.where(recorded_on: Date.current.all_year).count
 
     weather    = WeatherService.new.fetch
-    @rainy_now = weather.present? && WeatherRecord.rainy_main?(weather[:weather_main])
+    @rainy_now = weather.present? && WeatherRecord.rainy?(weather[:weather_main])
   end
 
   def show

--- a/app/helpers/diaries_helper.rb
+++ b/app/helpers/diaries_helper.rb
@@ -8,7 +8,7 @@ module DiariesHelper
   }.freeze
 
   def mood_dots(mood)
-    filled = mood.to_i.clamp(0, 5)
+    filled = mood.to_i
     empty  = 5 - filled
     safe_join([
       safe_join(Array.new(filled) { tag.i(class: "bi bi-circle-fill text-warning") }),

--- a/app/helpers/diaries_helper.rb
+++ b/app/helpers/diaries_helper.rb
@@ -1,0 +1,27 @@
+module DiariesHelper
+  WEATHER_ICONS = {
+    "Rain"    => "bi-cloud-rain",
+    "Drizzle" => "bi-cloud-drizzle",
+    "Clouds"  => "bi-cloud",
+    "Clear"   => "bi-sun",
+    "Snow"    => "bi-snow"
+  }.freeze
+
+  def mood_dots(mood)
+    filled = mood.to_i.clamp(0, 5)
+    empty  = 5 - filled
+    safe_join([
+      safe_join(Array.new(filled) { tag.i(class: "bi bi-circle-fill text-warning") }),
+      safe_join(Array.new(empty)  { tag.i(class: "bi bi-circle text-secondary") })
+    ])
+  end
+
+  def weather_icon_class(weather_main)
+    WEATHER_ICONS.fetch(weather_main, "bi-cloud")
+  end
+
+  def weather_icon_tag(weather_main, extra_class: nil)
+    classes = [ "bi", weather_icon_class(weather_main), extra_class ].compact.join(" ")
+    tag.i(class: classes)
+  end
+end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -2,7 +2,7 @@ class Diary < ApplicationRecord
   belongs_to :user
   has_one :weather_record, dependent: :destroy
 
-  delegate :weather_main, :description, :temp, :humidity, :rainfall_mm, :rainy?,
+  delegate :weather_main, :description, :temp, :humidity, :rainfall_mm,
            to: :weather_record, allow_nil: true
 
   validates :title, presence: true

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -2,6 +2,9 @@ class Diary < ApplicationRecord
   belongs_to :user
   has_one :weather_record, dependent: :destroy
 
+  delegate :weather_main, :description, :temp, :humidity, :rainfall_mm, :rainy?,
+           to: :weather_record, allow_nil: true
+
   validates :title, presence: true
   validates :body, presence: true
   validates :recorded_on, presence: true

--- a/app/models/weather_record.rb
+++ b/app/models/weather_record.rb
@@ -6,11 +6,7 @@ class WeatherRecord < ApplicationRecord
   validates :city_name, presence: true
   validates :weather_main, presence: true
 
-  def self.rainy_main?(weather_main)
+  def self.rainy?(weather_main)
     RAINY_MAINS.include?(weather_main)
-  end
-
-  def rainy?
-    self.class.rainy_main?(weather_main)
   end
 end

--- a/app/models/weather_record.rb
+++ b/app/models/weather_record.rb
@@ -1,6 +1,16 @@
 class WeatherRecord < ApplicationRecord
+  RAINY_MAINS = %w[Rain Drizzle].freeze
+
   belongs_to :diary
 
   validates :city_name, presence: true
   validates :weather_main, presence: true
+
+  def self.rainy_main?(weather_main)
+    RAINY_MAINS.include?(weather_main)
+  end
+
+  def rainy?
+    self.class.rainy_main?(weather_main)
+  end
 end

--- a/app/views/diaries/_diary_card.html.haml
+++ b/app/views/diaries/_diary_card.html.haml
@@ -3,7 +3,7 @@
     .d-flex.justify-content-between.align-items-start.mb-2
       %span.badge.bg-secondary= diary.recorded_on.strftime("%Y/%m/%d")
       - if diary.weather_record
-        = weather_icon_tag(diary.weather_main, extra_class: diary.rainy? ? "text-primary" : "text-info")
+        = weather_icon_tag(diary.weather_main, extra_class: WeatherRecord.rainy?(diary.weather_main) ? "text-primary" : "text-info")
     %h5.card-title= link_to diary.title, diary_path(diary), class: "stretched-link text-decoration-none text-dark"
     %p.card-text.text-muted.small= truncate(diary.body, length: 80)
     = mood_dots(diary.mood)

--- a/app/views/diaries/_diary_card.html.haml
+++ b/app/views/diaries/_diary_card.html.haml
@@ -1,0 +1,11 @@
+.card.h-100
+  .card-body
+    .d-flex.justify-content-between.align-items-start.mb-2
+      %span.badge.bg-secondary= diary.recorded_on.strftime("%Y/%m/%d")
+      - if diary.weather_record
+        = weather_icon_tag(diary.weather_main, extra_class: diary.rainy? ? "text-primary" : "text-info")
+    %h5.card-title= link_to diary.title, diary_path(diary), class: "stretched-link text-decoration-none text-dark"
+    %p.card-text.text-muted.small= truncate(diary.body, length: 80)
+    = mood_dots(diary.mood)
+    - if diary.weather_record
+      %small.text-muted.ms-2= "#{diary.temp&.round(1)}℃"

--- a/app/views/diaries/_form.html.haml
+++ b/app/views/diaries/_form.html.haml
@@ -1,6 +1,8 @@
 = simple_form_for diary do |f|
-  = f.input :title
-  = f.input :body
-  = f.input :recorded_on
-  = f.input :mood
-  = f.submit
+  = f.error_notification
+  .vstack.gap-3
+    = f.input :recorded_on, as: :date, input_html: { value: diary.recorded_on || Date.current }
+    = f.input :title
+    = f.input :body, as: :text, input_html: { rows: 8 }
+    = f.input :mood, as: :select, collection: (1..5).map { |i| [i, i] }, include_blank: false
+    = f.button :submit, "保存", class: "btn btn-primary"

--- a/app/views/diaries/edit.html.haml
+++ b/app/views/diaries/edit.html.haml
@@ -1,3 +1,3 @@
-%h1 日記を編集
-
-= render "form", diary: @diary
+.container
+  %h1.mb-4 日記を編集
+  = render "form", diary: @diary

--- a/app/views/diaries/index.html.haml
+++ b/app/views/diaries/index.html.haml
@@ -1,6 +1,29 @@
-%h1 日記一覧
+- if @rainy_now
+  .alert.alert-info.d-flex.align-items-center.gap-3
+    %i.bi.bi-cloud-rain-fill.fs-4
+    %div
+      %strong 今日は雨です
+      = link_to "今日の雨を記録する", new_diary_path, class: "btn btn-primary btn-sm ms-3"
+- else
+  .text-muted.mb-3
+    %i.bi.bi-sun
+    今日は雨ではありません
 
-- @diaries.each do |diary|
-  %div
-    = link_to diary.title, diary_path(diary)
-    = diary.recorded_on
+.row.g-3.mb-4
+  .col-md-6
+    .card.text-center
+      .card-body
+        %h5.card-title.text-muted 総記録数
+        %p.display-6= @total_count
+  .col-md-6
+    .card.text-center
+      .card-body
+        %h5.card-title.text-muted 今年の記録
+        %p.display-6= @yearly_count
+
+.row.row-cols-1.row-cols-md-2.g-3
+  - @diaries.each do |diary|
+    .col
+      = render "diary_card", diary: diary
+
+= paginate @diaries

--- a/app/views/diaries/new.html.haml
+++ b/app/views/diaries/new.html.haml
@@ -1,3 +1,3 @@
-%h1 日記を作成
-
-= render "form", diary: @diary
+.container
+  %h1.mb-4 新しい日記
+  = render "form", diary: @diary

--- a/app/views/diaries/show.html.haml
+++ b/app/views/diaries/show.html.haml
@@ -1,8 +1,34 @@
-%h1= @diary.title
+.row.justify-content-center
+  .col-md-8
+    .card.mb-4
+      .card-header.d-flex.justify-content-between.align-items-center
+        %span.badge.bg-secondary= @diary.recorded_on.strftime("%Y年%m月%d日")
+        = mood_dots(@diary.mood)
+      .card-body
+        %h3.card-title= @diary.title
+        %div= simple_format @diary.body
 
-%p= @diary.body
-%p= @diary.recorded_on
-%p= @diary.mood
+    - if @diary.weather_record
+      .card.mb-4
+        .card-header
+          = weather_icon_tag(@diary.weather_main)
+          天気情報
+        .card-body
+          .row.text-center
+            .col
+              %small.text-muted 天気
+              %div= @diary.description
+            .col
+              %small.text-muted 気温
+              %div= "#{@diary.temp&.round(1)}℃"
+            .col
+              %small.text-muted 湿度
+              %div= "#{@diary.humidity}%"
+            .col
+              %small.text-muted 降水量
+              %div= "#{@diary.rainfall_mm}mm"
 
-= link_to "編集", edit_diary_path(@diary)
-= link_to "一覧へ", diaries_path
+    .d-flex.gap-2
+      = link_to "一覧へ", diaries_path, class: "btn btn-outline-secondary"
+      = link_to "編集", edit_diary_path(@diary), class: "btn btn-outline-primary"
+      = button_to "削除", diary_path(@diary), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-outline-danger"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -22,6 +22,23 @@
     = stylesheet_link_tag :app, "data-turbo-track": "reload"
     = javascript_importmap_tags
   %body
-    %p.notice= notice
-    %p.alert= alert
-    = yield
+    %nav.navbar.navbar-expand-lg.navbar-dark.bg-primary.mb-0
+      .container
+        = link_to "Rain Diary", root_path, class: "navbar-brand"
+        .d-flex.align-items-center.gap-2
+          - if user_signed_in?
+            %span.navbar-text.text-white.me-2= current_user.email
+            = button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn btn-outline-light btn-sm", form: { class: "m-0" }
+          - else
+            = link_to "新規登録", new_user_registration_path, class: "btn btn-outline-light btn-sm"
+            = link_to "ログイン", new_user_session_path, class: "btn btn-light btn-sm"
+
+    - if notice
+      .container.mt-3
+        .alert.alert-success= notice
+    - if alert
+      .container.mt-3
+        .alert.alert-danger= alert
+
+    .container.py-4
+      = yield

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 #
 # Uncomment this and change the path if necessary to include your own
 # components.
@@ -75,7 +74,7 @@ SimpleForm.setup do |config|
   config.boolean_style = :nested
 
   # Default class for buttons
-  config.button_class = "btn"
+  config.button_class = 'btn'
 
   # Method used to tidy up errors. Specify any Rails Array method.
   # :first lists the first message for each field.
@@ -86,7 +85,7 @@ SimpleForm.setup do |config|
   config.error_notification_tag = :div
 
   # CSS class to add for error notification helper.
-  config.error_notification_class = "error_notification"
+  config.error_notification_class = 'error_notification'
 
   # Series of attempts to detect a default label method for collection.
   # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
@@ -162,7 +161,7 @@ SimpleForm.setup do |config|
   # config.input_class = nil
 
   # Define the default class of the input wrapper of the boolean input.
-  config.boolean_label_class = "checkbox"
+  config.boolean_label_class = 'checkbox'
 
   # Defines if the default input wrapper class should be included in radio
   # collection wrappers.

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -13,10 +13,10 @@
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
   # Default class for buttons
-  config.button_class = "btn"
+  config.button_class = 'btn'
 
   # Define the default class of the input wrapper of the boolean input.
-  config.boolean_label_class = "form-check-label"
+  config.boolean_label_class = 'form-check-label'
 
   # How the label text should be generated altogether with the required text.
   config.label_text = lambda { |label, required, explicit_label| "#{label} #{required}" }
@@ -32,7 +32,7 @@ SimpleForm.setup do |config|
   config.include_default_input_wrapper_class = false
 
   # CSS class to add for error notification helper.
-  config.error_notification_class = "alert alert-danger"
+  config.error_notification_class = 'alert alert-danger'
 
   # Method used to tidy up errors. Specify any Rails Array method.
   # :first lists the first message for each field.
@@ -40,14 +40,14 @@ SimpleForm.setup do |config|
   config.error_method = :to_sentence
 
   # add validation classes to `input_field`
-  config.input_field_error_class = "is-invalid"
-  config.input_field_valid_class = "is-valid"
+  config.input_field_error_class = 'is-invalid'
+  config.input_field_valid_class = 'is-valid'
 
 
   # vertical forms
   #
   # vertical default_wrapper
-  config.wrappers :vertical_form, class: "mb-3" do |b|
+  config.wrappers :vertical_form, class: 'mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -55,100 +55,100 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label, class: "form-label"
-    b.use :input, class: "form-control", error_class: "is-invalid", valid_class: "is-valid"
-    b.use :full_error, wrap_with: { class: "invalid-feedback" }
-    b.use :hint, wrap_with: { class: "form-text" }
+    b.use :label, class: 'form-label'
+    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
   # vertical input for boolean
-  config.wrappers :vertical_boolean, tag: "fieldset", class: "mb-3" do |b|
+  config.wrappers :vertical_boolean, tag: 'fieldset', class: 'mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :form_check_wrapper, class: "form-check" do |bb|
-      bb.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
-      bb.use :label, class: "form-check-label"
-      bb.use :full_error, wrap_with: { class: "invalid-feedback" }
-      bb.use :hint, wrap_with: { class: "form-text" }
+    b.wrapper :form_check_wrapper, class: 'form-check' do |bb|
+      bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      bb.use :label, class: 'form-check-label'
+      bb.use :full_error, wrap_with: { class: 'invalid-feedback' }
+      bb.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
   # vertical input for radio buttons and check boxes
-  config.wrappers :vertical_collection, item_wrapper_class: "form-check", item_label_class: "form-check-label", tag: "fieldset", class: "mb-3" do |b|
+  config.wrappers :vertical_collection, item_wrapper_class: 'form-check', item_label_class: 'form-check-label', tag: 'fieldset', class: 'mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :legend_tag, tag: "legend", class: "col-form-label pt-0" do |ba|
+    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
       ba.use :label_text
     end
-    b.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
-    b.use :full_error, wrap_with: { class: "invalid-feedback d-block" }
-    b.use :hint, wrap_with: { class: "form-text" }
+    b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
   # vertical input for inline radio buttons and check boxes
-  config.wrappers :vertical_collection_inline, item_wrapper_class: "form-check form-check-inline", item_label_class: "form-check-label", tag: "fieldset", class: "mb-3" do |b|
+  config.wrappers :vertical_collection_inline, item_wrapper_class: 'form-check form-check-inline', item_label_class: 'form-check-label', tag: 'fieldset', class: 'mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :legend_tag, tag: "legend", class: "col-form-label pt-0" do |ba|
+    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
       ba.use :label_text
     end
-    b.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
-    b.use :full_error, wrap_with: { class: "invalid-feedback d-block" }
-    b.use :hint, wrap_with: { class: "form-text" }
+    b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
   # vertical file input
-  config.wrappers :vertical_file, class: "mb-3" do |b|
+  config.wrappers :vertical_file, class: 'mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
     b.optional :minlength
     b.optional :readonly
-    b.use :label, class: "form-label"
-    b.use :input, class: "form-control", error_class: "is-invalid", valid_class: "is-valid"
-    b.use :full_error, wrap_with: { class: "invalid-feedback" }
-    b.use :hint, wrap_with: { class: "form-text" }
+    b.use :label, class: 'form-label'
+    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
   # vertical select input
-  config.wrappers :vertical_select, class: "mb-3" do |b|
+  config.wrappers :vertical_select, class: 'mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.use :label, class: "form-label"
-    b.use :input, class: "form-select", error_class: "is-invalid", valid_class: "is-valid"
-    b.use :full_error, wrap_with: { class: "invalid-feedback" }
-    b.use :hint, wrap_with: { class: "form-text" }
+    b.use :label, class: 'form-label'
+    b.use :input, class: 'form-select', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
   # vertical multi select
-  config.wrappers :vertical_multi_select, class: "mb-3" do |b|
+  config.wrappers :vertical_multi_select, class: 'mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.use :label, class: "form-label"
-    b.wrapper class: "d-flex flex-row justify-content-between align-items-center" do |ba|
-      ba.use :input, class: "form-select mx-1", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :label, class: 'form-label'
+    b.wrapper class: 'd-flex flex-row justify-content-between align-items-center' do |ba|
+      ba.use :input, class: 'form-select mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
     end
-    b.use :full_error, wrap_with: { class: "invalid-feedback d-block" }
-    b.use :hint, wrap_with: { class: "form-text" }
+    b.use :full_error, wrap_with: { class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
   # vertical range input
-  config.wrappers :vertical_range, class: "mb-3" do |b|
+  config.wrappers :vertical_range, class: 'mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :readonly
     b.optional :step
-    b.use :label, class: "form-label"
-    b.use :input, class: "form-range", error_class: "is-invalid", valid_class: "is-valid"
-    b.use :full_error, wrap_with: { class: "invalid-feedback" }
-    b.use :hint, wrap_with: { class: "form-text" }
+    b.use :label, class: 'form-label'
+    b.use :input, class: 'form-range', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
 
   # horizontal forms
   #
   # horizontal default_wrapper
-  config.wrappers :horizontal_form, class: "row mb-3" do |b|
+  config.wrappers :horizontal_form, class: 'row mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -156,104 +156,104 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label, class: "col-sm-3 col-form-label"
-    b.wrapper :grid_wrapper, class: "col-sm-9" do |ba|
-      ba.use :input, class: "form-control", error_class: "is-invalid", valid_class: "is-valid"
-      ba.use :full_error, wrap_with: { class: "invalid-feedback" }
-      ba.use :hint, wrap_with: { class: "form-text" }
+    b.use :label, class: 'col-sm-3 col-form-label'
+    b.wrapper :grid_wrapper, class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback' }
+      ba.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
   # horizontal input for boolean
-  config.wrappers :horizontal_boolean, class: "row mb-3" do |b|
+  config.wrappers :horizontal_boolean, class: 'row mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :grid_wrapper, class: "col-sm-9 offset-sm-3" do |wr|
-      wr.wrapper :form_check_wrapper, class: "form-check" do |bb|
-        bb.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
-        bb.use :label, class: "form-check-label"
-        bb.use :full_error, wrap_with: { class: "invalid-feedback" }
-        bb.use :hint, wrap_with: { class: "form-text" }
+    b.wrapper :grid_wrapper, class: 'col-sm-9 offset-sm-3' do |wr|
+      wr.wrapper :form_check_wrapper, class: 'form-check' do |bb|
+        bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+        bb.use :label, class: 'form-check-label'
+        bb.use :full_error, wrap_with: { class: 'invalid-feedback' }
+        bb.use :hint, wrap_with: { class: 'form-text' }
       end
     end
   end
 
   # horizontal input for radio buttons and check boxes
-  config.wrappers :horizontal_collection, item_wrapper_class: "form-check", item_label_class: "form-check-label", class: "row mb-3" do |b|
+  config.wrappers :horizontal_collection, item_wrapper_class: 'form-check', item_label_class: 'form-check-label', class: 'row mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.use :label, class: "col-sm-3 col-form-label pt-0"
-    b.wrapper :grid_wrapper, class: "col-sm-9" do |ba|
-      ba.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
-      ba.use :full_error, wrap_with: { class: "invalid-feedback d-block" }
-      ba.use :hint, wrap_with: { class: "form-text" }
+    b.use :label, class: 'col-sm-3 col-form-label pt-0'
+    b.wrapper :grid_wrapper, class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
   # horizontal input for inline radio buttons and check boxes
-  config.wrappers :horizontal_collection_inline, item_wrapper_class: "form-check form-check-inline", item_label_class: "form-check-label", class: "row mb-3" do |b|
+  config.wrappers :horizontal_collection_inline, item_wrapper_class: 'form-check form-check-inline', item_label_class: 'form-check-label', class: 'row mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.use :label, class: "col-sm-3 col-form-label pt-0"
-    b.wrapper :grid_wrapper, class: "col-sm-9" do |ba|
-      ba.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
-      ba.use :full_error, wrap_with: { class: "invalid-feedback d-block" }
-      ba.use :hint, wrap_with: { class: "form-text" }
+    b.use :label, class: 'col-sm-3 col-form-label pt-0'
+    b.wrapper :grid_wrapper, class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
   # horizontal file input
-  config.wrappers :horizontal_file, class: "row mb-3" do |b|
+  config.wrappers :horizontal_file, class: 'row mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
     b.optional :minlength
     b.optional :readonly
-    b.use :label, class: "col-sm-3 col-form-label"
-    b.wrapper :grid_wrapper, class: "col-sm-9" do |ba|
-      ba.use :input, class: "form-control", error_class: "is-invalid", valid_class: "is-valid"
-      ba.use :full_error, wrap_with: { class: "invalid-feedback" }
-      ba.use :hint, wrap_with: { class: "form-text" }
+    b.use :label, class: 'col-sm-3 col-form-label'
+    b.wrapper :grid_wrapper, class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback' }
+      ba.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
   # horizontal select input
-  config.wrappers :horizontal_select, class: "row mb-3" do |b|
+  config.wrappers :horizontal_select, class: 'row mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.use :label, class: "col-sm-3 col-form-label"
-    b.wrapper :grid_wrapper, class: "col-sm-9" do |ba|
-      ba.use :input, class: "form-select", error_class: "is-invalid", valid_class: "is-valid"
-      ba.use :full_error, wrap_with: { class: "invalid-feedback" }
-      ba.use :hint, wrap_with: { class: "form-text" }
+    b.use :label, class: 'col-sm-3 col-form-label'
+    b.wrapper :grid_wrapper, class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-select', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback' }
+      ba.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
   # horizontal multi select
-  config.wrappers :horizontal_multi_select, class: "row mb-3" do |b|
+  config.wrappers :horizontal_multi_select, class: 'row mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.use :label, class: "col-sm-3 col-form-label"
-    b.wrapper :grid_wrapper, class: "col-sm-9" do |ba|
-      ba.wrapper class: "d-flex flex-row justify-content-between align-items-center" do |bb|
-        bb.use :input, class: "form-select mx-1", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :label, class: 'col-sm-3 col-form-label'
+    b.wrapper :grid_wrapper, class: 'col-sm-9' do |ba|
+      ba.wrapper class: 'd-flex flex-row justify-content-between align-items-center' do |bb|
+        bb.use :input, class: 'form-select mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
       end
-      ba.use :full_error, wrap_with: { class: "invalid-feedback d-block" }
-      ba.use :hint, wrap_with: { class: "form-text" }
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
   # horizontal range input
-  config.wrappers :horizontal_range, class: "row mb-3" do |b|
+  config.wrappers :horizontal_range, class: 'row mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :readonly
     b.optional :step
-    b.use :label, class: "col-sm-3 col-form-label pt-0"
-    b.wrapper :grid_wrapper, class: "col-sm-9" do |ba|
-      ba.use :input, class: "form-range", error_class: "is-invalid", valid_class: "is-valid"
-      ba.use :full_error, wrap_with: { class: "invalid-feedback" }
-      ba.use :hint, wrap_with: { class: "form-text" }
+    b.use :label, class: 'col-sm-3 col-form-label pt-0'
+    b.wrapper :grid_wrapper, class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-range', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback' }
+      ba.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
@@ -261,7 +261,7 @@ SimpleForm.setup do |config|
   # inline forms
   #
   # inline default_wrapper
-  config.wrappers :inline_form, class: "col-12" do |b|
+  config.wrappers :inline_form, class: 'col-12' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -269,22 +269,22 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label, class: "visually-hidden"
+    b.use :label, class: 'visually-hidden'
 
-    b.use :input, class: "form-control", error_class: "is-invalid", valid_class: "is-valid"
-    b.use :error, wrap_with: { class: "invalid-feedback" }
-    b.optional :hint, wrap_with: { class: "form-text" }
+    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :error, wrap_with: { class: 'invalid-feedback' }
+    b.optional :hint, wrap_with: { class: 'form-text' }
   end
 
   # inline input for boolean
-  config.wrappers :inline_boolean, class: "col-12" do |b|
+  config.wrappers :inline_boolean, class: 'col-12' do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :form_check_wrapper, class: "form-check" do |bb|
-      bb.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
-      bb.use :label, class: "form-check-label"
-      bb.use :error, wrap_with: { class: "invalid-feedback" }
-      bb.optional :hint, wrap_with: { class: "form-text" }
+    b.wrapper :form_check_wrapper, class: 'form-check' do |bb|
+      bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      bb.use :label, class: 'form-check-label'
+      bb.use :error, wrap_with: { class: 'invalid-feedback' }
+      bb.optional :hint, wrap_with: { class: 'form-text' }
     end
   end
 
@@ -292,21 +292,21 @@ SimpleForm.setup do |config|
   # bootstrap custom forms
   #
   # custom input switch for boolean
-  config.wrappers :custom_boolean_switch, class: "mb-3" do |b|
+  config.wrappers :custom_boolean_switch, class: 'mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :form_check_wrapper, tag: "div", class: "form-check form-switch" do |bb|
-      bb.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
-      bb.use :label, class: "form-check-label"
-      bb.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
-      bb.use :hint, wrap_with: { class: "form-text" }
+    b.wrapper :form_check_wrapper, tag: 'div', class: 'form-check form-switch' do |bb|
+      bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      bb.use :label, class: 'form-check-label'
+      bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+      bb.use :hint, wrap_with: { class: 'form-text' }
     end
   end
 
 
   # Input Group - custom component
   # see example app and config at https://github.com/heartcombo/simple_form-bootstrap
-  config.wrappers :input_group, class: "mb-3" do |b|
+  config.wrappers :input_group, class: 'mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -314,21 +314,21 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label, class: "form-label"
-    b.wrapper :input_group_tag, class: "input-group" do |ba|
+    b.use :label, class: 'form-label'
+    b.wrapper :input_group_tag, class: 'input-group' do |ba|
       ba.optional :prepend
-      ba.use :input, class: "form-control", error_class: "is-invalid", valid_class: "is-valid"
+      ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
       ba.optional :append
-      ba.use :full_error, wrap_with: { class: "invalid-feedback" }
+      ba.use :full_error, wrap_with: { class: 'invalid-feedback' }
     end
-    b.use :hint, wrap_with: { class: "form-text" }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
 
   # Floating Labels form
   #
   # floating labels default_wrapper
-  config.wrappers :floating_labels_form, class: "form-floating mb-3" do |b|
+  config.wrappers :floating_labels_form, class: 'form-floating mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -336,20 +336,20 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :input, class: "form-control", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :label
-    b.use :full_error, wrap_with: { class: "invalid-feedback" }
-    b.use :hint, wrap_with: { class: "form-text" }
+    b.use :full_error, wrap_with: { class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
   # custom multi select
-  config.wrappers :floating_labels_select, class: "form-floating mb-3" do |b|
+  config.wrappers :floating_labels_select, class: 'form-floating mb-3' do |b|
     b.use :html5
     b.optional :readonly
-    b.use :input, class: "form-select", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :input, class: 'form-select', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :label
-    b.use :full_error, wrap_with: { class: "invalid-feedback" }
-    b.use :hint, wrap_with: { class: "form-text" }
+    b.use :full_error, wrap_with: { class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { class: 'form-text' }
   end
 
 

--- a/spec/helpers/diaries_helper_spec.rb
+++ b/spec/helpers/diaries_helper_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe DiariesHelper, type: :helper do
+  describe "#mood_dots" do
+    it "mood=3で塗りつぶしが3個、空が2個含まれる" do
+      output = helper.mood_dots(3)
+      expect(output.scan("bi-circle-fill").size).to eq 3
+      expect(output.scan(/bi-circle(?!-fill)/).size).to eq 2
+    end
+
+    it "mood=5で塗りつぶしが5個含まれる" do
+      output = helper.mood_dots(5)
+      expect(output.scan("bi-circle-fill").size).to eq 5
+    end
+
+    it "mood=1で空が4個含まれる" do
+      output = helper.mood_dots(1)
+      expect(output.scan(/bi-circle(?!-fill)/).size).to eq 4
+    end
+  end
+
+  describe "#weather_icon_class" do
+    it "Rainに対応するアイコンクラスを返す" do
+      expect(helper.weather_icon_class("Rain")).to eq "bi-cloud-rain"
+    end
+
+    it "未定義のweather_mainではデフォルトを返す" do
+      expect(helper.weather_icon_class("Unknown")).to eq "bi-cloud"
+    end
+  end
+
+  describe "#weather_icon_tag" do
+    it "i要素にweather_mainに応じたbiクラスを付与する" do
+      expect(helper.weather_icon_tag("Rain")).to include("bi", "bi-cloud-rain")
+    end
+
+    it "extra_classが追加される" do
+      expect(helper.weather_icon_tag("Rain", extra_class: "text-info")).to include("text-info")
+    end
+  end
+end

--- a/spec/models/weather_record_spec.rb
+++ b/spec/models/weather_record_spec.rb
@@ -29,4 +29,22 @@ RSpec.describe WeatherRecord, type: :model do
       end
     end
   end
+
+  describe "#rainy?" do
+    it "weather_mainがRainの場合はtrue" do
+      expect(build(:weather_record, weather_main: "Rain").rainy?).to be true
+    end
+
+    it "weather_mainがDrizzleの場合はtrue" do
+      expect(build(:weather_record, weather_main: "Drizzle").rainy?).to be true
+    end
+
+    it "weather_mainがClearの場合はfalse" do
+      expect(build(:weather_record, weather_main: "Clear").rainy?).to be false
+    end
+
+    it "weather_mainがCloudsの場合はfalse" do
+      expect(build(:weather_record, weather_main: "Clouds").rainy?).to be false
+    end
+  end
 end

--- a/spec/models/weather_record_spec.rb
+++ b/spec/models/weather_record_spec.rb
@@ -30,21 +30,21 @@ RSpec.describe WeatherRecord, type: :model do
     end
   end
 
-  describe "#rainy?" do
+  describe ".rainy?" do
     it "weather_mainがRainの場合はtrue" do
-      expect(build(:weather_record, weather_main: "Rain").rainy?).to be true
+      expect(WeatherRecord.rainy?("Rain")).to be true
     end
 
     it "weather_mainがDrizzleの場合はtrue" do
-      expect(build(:weather_record, weather_main: "Drizzle").rainy?).to be true
+      expect(WeatherRecord.rainy?("Drizzle")).to be true
     end
 
     it "weather_mainがClearの場合はfalse" do
-      expect(build(:weather_record, weather_main: "Clear").rainy?).to be false
+      expect(WeatherRecord.rainy?("Clear")).to be false
     end
 
     it "weather_mainがCloudsの場合はfalse" do
-      expect(build(:weather_record, weather_main: "Clouds").rainy?).to be false
+      expect(WeatherRecord.rainy?("Clouds")).to be false
     end
   end
 end

--- a/spec/requests/diaries_spec.rb
+++ b/spec/requests/diaries_spec.rb
@@ -18,6 +18,41 @@ RSpec.describe "Diaries", type: :request do
         get diaries_path
         expect(response).to have_http_status(:ok)
       end
+
+      context "WeatherService が Rain を返すとき" do
+        before do
+          allow_any_instance_of(WeatherService).to receive(:fetch).and_return(
+            { weather_main: "Rain", city_name: "Tokyo", description: "雨", temp: 15.0, humidity: 80, rainfall_mm: 3.0 }
+          )
+        end
+
+        it "今日の雨を記録するリンクが表示される" do
+          get diaries_path
+          expect(response.body).to include("今日の雨を記録する")
+        end
+      end
+
+      context "WeatherService が Clear を返すとき" do
+        before do
+          allow_any_instance_of(WeatherService).to receive(:fetch).and_return(
+            { weather_main: "Clear", city_name: "Tokyo", description: "晴れ", temp: 25.0, humidity: 50, rainfall_mm: 0.0 }
+          )
+        end
+
+        it "今日は雨ではありませんが表示される" do
+          get diaries_path
+          expect(response.body).to include("今日は雨ではありません")
+        end
+      end
+
+      context "WeatherService が nil を返すとき" do
+        before { allow_any_instance_of(WeatherService).to receive(:fetch).and_return(nil) }
+
+        it "雨でない表示になる" do
+          get diaries_path
+          expect(response.body).to include("今日は雨ではありません")
+        end
+      end
     end
   end
 
@@ -112,6 +147,41 @@ RSpec.describe "Diaries", type: :request do
         delete diary_path(diary)
       }.to change(user.diaries, :count).by(-1)
       expect(response).to redirect_to(diaries_path)
+    end
+  end
+
+  context "他人の日記に対するアクセス" do
+    let(:other_user)   { create(:user) }
+    let!(:other_diary) { create(:diary, user: other_user) }
+
+    before { sign_in user }
+
+    describe "GET /diaries/:id" do
+      it "リダイレクトされる" do
+        get diary_path(other_diary)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    describe "GET /diaries/:id/edit" do
+      it "リダイレクトされる" do
+        get edit_diary_path(other_diary)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    describe "PATCH /diaries/:id" do
+      it "リダイレクトされる" do
+        patch diary_path(other_diary), params: { diary: { title: "改ざん" } }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    describe "DELETE /diaries/:id" do
+      it "リダイレクトされる" do
+        delete diary_path(other_diary)
+        expect(response).to redirect_to(root_path)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- simple_form Bootstrap 5 化・Bootstrap navbar・フラッシュ alert をレイアウトに追加
- 一覧（雨バナー・件数カード・Kaminari ページネーション）・詳細・フォームを Bootstrap カード型に刷新し、mood ドット表示・天気アイコンを実装
- `DiariesController#index` で `WeatherService` による雨判定を実装、`set_diary` を `policy_scope` 経由に変更してリソース存在漏洩を防止

## Test plan

- [ ] `bundle exec rspec` — 76 examples, 0 failures
- [ ] `bin/rubocop` — 0 offenses
- [ ] `bin/brakeman --no-pager` — 0 warnings
- [ ] `bin/rails_best_practices` — no warnings
- [ ] ブラウザで `/diaries` を開き雨バナー・件数カード・カード一覧が表示されることを確認
- [ ] 新規作成・編集・削除が正常に動作することを確認
- [ ] 他人の日記URL に直接アクセスして root にリダイレクトされることを確認

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced diary cards with mood dots, weather icon and temp display
  * Improved diary form: date picker default, textarea, mood selector (1–5), validation errors and styled save button
  * Dashboard metrics (total/yearly), responsive card grid, pagination and current-day weather banner

* **Bug Fixes**
  * Missing resources now handled gracefully with an alert and redirect to home

* **Style**
  * Updated card-based diary layouts and responsive navbar with improved spacing

* **Tests**
  * Added helper, model and request specs covering new UI and weather logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->