### PR TITLE
style: フォーム見出し削除と主要ボタンのソリッド化で可読性を向上

### DIFF
--- a/app/views/diaries/_form.html.haml
+++ b/app/views/diaries/_form.html.haml
@@ -5,4 +5,4 @@
     = f.input :title
     = f.input :body, as: :text, input_html: { rows: 8 }
     = f.input :mood, as: :select, collection: (1..5).map { |i| [i, i] }, include_blank: false
-    = f.button :submit, "保存", class: "btn btn-outline-primary"
+    = f.button :submit, "保存", class: "btn btn-primary"

--- a/app/views/diaries/edit.html.haml
+++ b/app/views/diaries/edit.html.haml
@@ -1,3 +1,2 @@
 .container
-  %h1.mb-4 日記を編集
   = render "form", diary: @diary

--- a/app/views/diaries/index.html.haml
+++ b/app/views/diaries/index.html.haml
@@ -3,7 +3,7 @@
     %i.bi.bi-cloud-rain-fill.fs-4
     %div
       %strong 今日は雨です
-      = link_to "今日の雨を記録する", new_diary_path, class: "btn btn-outline-primary btn-sm ms-3"
+      = link_to "今日の雨を記録する", new_diary_path, class: "btn btn-primary btn-sm ms-3"
 - else
   .text-muted.mb-3
     %i.bi.bi-sun

--- a/app/views/diaries/new.html.haml
+++ b/app/views/diaries/new.html.haml
@@ -1,3 +1,2 @@
 .container
-  %h1.mb-4 新しい日記
   = render "form", diary: @diary

--- a/app/views/diaries/show.html.haml
+++ b/app/views/diaries/show.html.haml
@@ -29,6 +29,6 @@
               %div= "#{@diary.rainfall_mm}mm"
 
     .d-flex.gap-2
-      = link_to "一覧へ", diaries_path, class: "btn btn-outline-secondary"
-      = link_to "編集", edit_diary_path(@diary), class: "btn btn-outline-primary"
+      = link_to "一覧へ", diaries_path, class: "btn btn-secondary"
+      = link_to "編集", edit_diary_path(@diary), class: "btn btn-primary"
       = button_to "削除", diary_path(@diary), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-outline-danger"


### PR DESCRIPTION
## Summary

- `new` / `edit` フォーム画面の冗長な `h1` 見出し（「新しい日記」「日記を編集」）を削除
- `show` の「一覧へ」「編集」、フォームの「保存」、一覧の「今日の雨を記録する」を `btn-outline-*` → solid ボタンに変更し、淡い背景との同化を解消
- 「削除」ボタンは誤操作防止のため `btn-outline-danger` のまま据え置き

## Test plan

- [ ] `bundle exec rspec` — 73 tests pass
- [ ] `bundle exec rubocop` — no offenses
- [ ] `bundle exec brakeman -q` — 0 warnings
- [ ] `/diaries/new` `/diaries/:id/edit` で h1 見出しが表示されないこと
- [ ] `/diaries/:id` で「一覧へ」「編集」ボタンが背景と同化せず明瞭に見えること
- [ ] フォームの「保存」ボタンが明瞭に見えること
- [ ] 一覧画面（雨の日）で「今日の雨を記録する」ボタンが alert-info 内で明瞭に見えること

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated button styling across diary pages for a consistent filled appearance.
  * Removed page headers from diary creation and edit views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->