### PR TITLE
feat: WeatherService.fetch に1時間キャッシュを追加 (#18)

### DIFF
--- a/app/services/weather_service.rb
+++ b/app/services/weather_service.rb
@@ -18,8 +18,9 @@ class WeatherService
   private
 
   def fetch_uncached
-    Rails.logger.debug("[WeatherService] calling API")
     return nil if @api_key.blank?
+
+    Rails.logger.debug("[WeatherService] calling API")
 
     response = build_connection.get(ENDPOINT) do |req|
       req.params.merge!(

--- a/app/services/weather_service.rb
+++ b/app/services/weather_service.rb
@@ -4,12 +4,21 @@ class WeatherService
   CITY_NAME = "Tokyo"
   BASE_URL  = "https://api.openweathermap.org"
   ENDPOINT  = "/data/2.5/weather"
+  CACHE_KEY = "weather:current"
+  CACHE_TTL = 1.hour
 
   def initialize(api_key: ENV["OPENWEATHER_API_KEY"])
     @api_key = api_key
   end
 
   def fetch
+    Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL, skip_nil: true) { fetch_uncached }
+  end
+
+  private
+
+  def fetch_uncached
+    Rails.logger.debug("[WeatherService] calling API")
     return nil if @api_key.blank?
 
     response = build_connection.get(ENDPOINT) do |req|
@@ -28,8 +37,6 @@ class WeatherService
     Rails.logger.error("[WeatherService] Faraday error: #{e.class}")
     nil
   end
-
-  private
 
   def build_connection
     Faraday.new(url: BASE_URL) do |f|

--- a/spec/services/weather_service_spec.rb
+++ b/spec/services/weather_service_spec.rb
@@ -134,4 +134,61 @@ RSpec.describe WeatherService do
       end
     end
   end
+
+  describe "#fetch キャッシュ動作" do
+    include ActiveSupport::Testing::TimeHelpers
+
+    before do
+      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+    end
+
+    def counting_connection(count_ref, status:, body:)
+      stubs = Faraday::Adapter::Test::Stubs.new
+      stubs.get(WeatherService::ENDPOINT) do
+        count_ref[:n] += 1
+        [ status, { "Content-Type" => "application/json" }, body ]
+      end
+      Faraday.new(url: WeatherService::BASE_URL) { |f| f.response :json; f.adapter :test, stubs }
+    end
+
+    it "成功時: 2回呼んでも API は1回のみ呼ばれる" do
+      count = { n: 0 }
+      conn = counting_connection(count, status: 200, body: success_body_with_rain)
+      allow(service).to receive(:build_connection).and_return(conn)
+
+      result1 = service.fetch
+      result2 = service.fetch
+
+      expect(count[:n]).to eq(1)
+      expect(result1).to eq(result2)
+    end
+
+    it "失敗(nil)はキャッシュされず次回呼び出しで再試行する" do
+      stubs_500 = Faraday::Adapter::Test::Stubs.new
+      stubs_500.get(WeatherService::ENDPOINT) { [ 500, { "Content-Type" => "application/json" }, {} ] }
+      conn500 = Faraday.new(url: WeatherService::BASE_URL) { |f| f.response :json; f.adapter :test, stubs_500 }
+
+      stubs_200 = Faraday::Adapter::Test::Stubs.new
+      stubs_200.get(WeatherService::ENDPOINT) { [ 200, { "Content-Type" => "application/json" }, success_body_with_rain ] }
+      conn200 = Faraday.new(url: WeatherService::BASE_URL) { |f| f.response :json; f.adapter :test, stubs_200 }
+
+      allow(service).to receive(:build_connection).and_return(conn500, conn200)
+
+      expect(service.fetch).to be_nil
+      expect(service.fetch).to be_a(Hash)
+    end
+
+    it "TTL 経過後は API を再呼び出しする" do
+      count = { n: 0 }
+      conn = counting_connection(count, status: 200, body: success_body_with_rain)
+      allow(service).to receive(:build_connection).and_return(conn)
+
+      service.fetch
+      travel_to(WeatherService::CACHE_TTL.from_now + 1.second) do
+        service.fetch
+      end
+
+      expect(count[:n]).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- `Rails.cache.fetch` で天気データを1時間キャッシュし、OpenWeatherMap API の呼び出し回数を抑制
- `skip_nil: true` により API 失敗時（nil）はキャッシュしない（次回呼び出しで再試行）
- キャッシュヒット/ミスを `Rails.logger.debug` で確認可能

## Test plan

- [ ] `bundle exec rspec spec/services/weather_service_spec.rb` — 既存テスト + キャッシュ動作3ケース（成功時キャッシュ / nil非キャッシュ / TTL経過後再呼び出し）が green
- [ ] `bundle exec rspec` — 全体 green
- [ ] ブラウザで index を複数回リロードし、ログに `[WeatherService] calling API` が初回のみ出ることを確認

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weather API responses are now cached to improve performance and reduce unnecessary API calls. Cached results automatically refresh after one hour. Failed requests are not cached and will be retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->