### PR TITLE
feat: Diary の title/body に文字数バリデーションを追加

### DIFF
--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -5,8 +5,8 @@ class Diary < ApplicationRecord
   delegate :weather_main, :description, :temp, :humidity, :rainfall_mm,
            to: :weather_record, allow_nil: true
 
-  validates :title, presence: true
-  validates :body, presence: true
+  validates :title, presence: true, length: { maximum: 100 }
+  validates :body, presence: true, length: { maximum: 10_000 }
   validates :recorded_on, presence: true
   validates :mood, presence: true, numericality: { only_integer: true }, inclusion: { in: 1..5 }
 

--- a/spec/models/diary_spec.rb
+++ b/spec/models/diary_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe Diary, type: :model do
       it "titleがあれば有効" do
         expect(build(:diary, title: "タイトル")).to be_valid
       end
+
+      it "titleが100文字なら有効" do
+        expect(build(:diary, title: "あ" * 100)).to be_valid
+      end
+
+      it "titleが101文字なら無効" do
+        expect(build(:diary, title: "あ" * 101)).not_to be_valid
+      end
     end
 
     context "body" do
@@ -32,6 +40,14 @@ RSpec.describe Diary, type: :model do
 
       it "bodyがあれば有効" do
         expect(build(:diary, body: "本文")).to be_valid
+      end
+
+      it "bodyが10,000文字なら有効" do
+        expect(build(:diary, body: "あ" * 10_000)).to be_valid
+      end
+
+      it "bodyが10,001文字なら無効" do
+        expect(build(:diary, body: "あ" * 10_001)).not_to be_valid
       end
     end
 


### PR DESCRIPTION
## Summary

- `Diary` モデルの `title` に最大 100 文字のバリデーションを追加
- `Diary` モデルの `body` に最大 10,000 文字のバリデーションを追加
- 各バリデーションに対応する RSpec 境界値テスト 4 件を追加

## Test plan

- [ ] `bundle exec rspec spec/models/diary_spec.rb` — 全テストが通過すること
- [ ] `title` が 100 文字のとき valid、101 文字のとき invalid になること
- [ ] `body` が 10,000 文字のとき valid、10,001 文字のとき invalid になること

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added length validation limits for diary entries: titles are now limited to 100 characters maximum, and body content to 10,000 characters maximum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->