### PR TITLE
feat: 編集・削除ボタンをアイコンに移動し戻るボタン共通パーシャルを追加 (#36)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   include Pundit::Authorization
 
+  helper_method :url_from
+
   allow_browser versions: :modern
   stale_when_importmap_changes
 

--- a/app/views/diaries/edit.html.haml
+++ b/app/views/diaries/edit.html.haml
@@ -1,2 +1,3 @@
 .container
+  = render "shared/back_button"
   = render "form", diary: @diary

--- a/app/views/diaries/new.html.haml
+++ b/app/views/diaries/new.html.haml
@@ -1,2 +1,3 @@
 .container
+  = render "shared/back_button"
   = render "form", diary: @diary

--- a/app/views/diaries/show.html.haml
+++ b/app/views/diaries/show.html.haml
@@ -1,9 +1,18 @@
+= render "shared/back_button"
+
 .row.justify-content-center
   .col-md-8
     .card.mb-4.shadow-sm.border-0
       .card-header.d-flex.justify-content-between.align-items-center
         %span.badge.bg-secondary-subtle.text-secondary-emphasis= @diary.recorded_on.strftime("%Y年%m月%d日")
-        = mood_dots(@diary.mood)
+        .d-flex.align-items-center.gap-2
+          = mood_dots(@diary.mood)
+          - if policy(@diary).edit?
+            = link_to edit_diary_path(@diary), class: "btn btn-sm btn-link link-secondary p-0", "aria-label": "編集" do
+              %i.bi.bi-pencil
+          - if policy(@diary).destroy?
+            = button_to diary_path(@diary), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-sm btn-link link-danger p-0", form: { class: "d-inline m-0" }, "aria-label": "削除" do
+              %i.bi.bi-trash
       .card-body
         %h3.card-title= @diary.title
         %div= simple_format @diary.body
@@ -27,8 +36,3 @@
             .col
               %small.text-muted 降水量
               %div= "#{@diary.rainfall_mm}mm"
-
-    .d-flex.gap-2
-      = link_to "一覧へ", diaries_path, class: "btn btn-secondary"
-      = link_to "編集", edit_diary_path(@diary), class: "btn btn-primary"
-      = button_to "削除", diary_path(@diary), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-outline-danger"

--- a/app/views/shared/_back_button.html.haml
+++ b/app/views/shared/_back_button.html.haml
@@ -1,0 +1,3 @@
+= link_to (url_from(request.referer) || root_path), class: "btn btn-outline-secondary btn-sm mb-3" do
+  %i.bi.bi-arrow-left.me-1
+  戻る

--- a/spec/requests/diaries_spec.rb
+++ b/spec/requests/diaries_spec.rb
@@ -65,6 +65,22 @@ RSpec.describe "Diaries", type: :request do
       get diary_path(diary)
       expect(response).to have_http_status(:ok)
     end
+
+    it "戻るボタンが描画される" do
+      get diary_path(diary)
+      expect(response.body).to include("戻る")
+    end
+
+    it "編集アイコンが描画される" do
+      get diary_path(diary)
+      expect(response.body).to include("bi-pencil")
+    end
+
+    it "削除アイコンが描画される" do
+      get diary_path(diary)
+      expect(response.body).to include("bi-trash")
+    end
+
   end
 
   describe "POST /diaries" do
@@ -114,6 +130,15 @@ RSpec.describe "Diaries", type: :request do
     end
   end
 
+  describe "GET /diaries/new" do
+    before { sign_in user }
+
+    it "戻るボタンが描画される" do
+      get new_diary_path
+      expect(response.body).to include("戻る")
+    end
+  end
+
   describe "GET /diaries/:id/edit" do
     let!(:diary) { create(:diary, user: user) }
 
@@ -122,6 +147,11 @@ RSpec.describe "Diaries", type: :request do
     it "自分のdiaryの編集ページを表示する" do
       get edit_diary_path(diary)
       expect(response).to have_http_status(:ok)
+    end
+
+    it "戻るボタンが描画される" do
+      get edit_diary_path(diary)
+      expect(response.body).to include("戻る")
     end
   end
 

--- a/spec/requests/diaries_spec.rb
+++ b/spec/requests/diaries_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe "Diaries", type: :request do
       get diary_path(diary)
       expect(response.body).to include("bi-trash")
     end
-
   end
 
   describe "POST /diaries" do


### PR DESCRIPTION
## Summary

- show ページの編集・削除ボタンを廃止し、カードヘッダに `bi-pencil` / `bi-trash` アイコンボタンを配置（Pundit ポリシーガード付き）
- `app/views/shared/_back_button.html.haml` を新設。`url_from(request.referer)` で Open Redirect を防ぎつつ「← 戻る」リンクを描画
- show / new / edit ページに戻るボタンを追加し、「一覧へ」ボタンを削除

## Test plan

- [ ] `bundle exec rspec spec/requests/diaries_spec.rb` — 戻るボタン・bi-pencil・bi-trash の描画テストを含む全件パス
- [ ] show ページで編集・削除アイコンが表示されること（自分の日記のみ）
- [ ] show / new / edit ページで「← 戻る」ボタンが表示されること
- [ ] 外部ドメインを Referer に指定しても `/` へリダイレクトされること（Open Redirect 対策）

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a back button to diary pages (create, edit, and view) for improved navigation, which intelligently links to the previous page when available.
  * Restructured the diary view page to display mood indicators and conditionally show edit and delete controls based on permissions.

* **Tests**
  * Added request specs to verify back button and action controls appear on diary pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->