### PR TITLE
feat: 日記の日付を当日固定・編集時変更不可にする

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -22,6 +22,7 @@ class DiariesController < ApplicationController
 
   def create
     @diary = current_user.diaries.build(diary_params)
+    @diary.recorded_on = Date.current # NOTE: 雨の日以外を選択出来ないように日付は固定
     authorize @diary
     if @diary.save
       @diary.attach_weather!
@@ -57,6 +58,6 @@ class DiariesController < ApplicationController
   end
 
   def diary_params
-    params.require(:diary).permit(:title, :body, :recorded_on, :mood)
+    params.require(:diary).permit(:title, :body, :mood)
   end
 end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -10,10 +10,25 @@ class Diary < ApplicationRecord
   validates :recorded_on, presence: true
   validates :mood, presence: true, numericality: { only_integer: true }, inclusion: { in: 1..5 }
 
+  validate :recorded_on_must_be_today, on: :create
+  validate :recorded_on_must_not_change, on: :update
+
   def attach_weather!
     weather_data = WeatherService.new.fetch
     return if weather_data.blank?
 
     create_weather_record!(weather_data)
+  end
+
+  private
+
+  def recorded_on_must_be_today
+    return if recorded_on.blank?
+
+    errors.add(:recorded_on, "は本日のみ指定できます") if recorded_on != Date.current
+  end
+
+  def recorded_on_must_not_change
+    errors.add(:recorded_on, "は変更できません") if recorded_on_changed?
   end
 end

--- a/app/views/diaries/_form.html.haml
+++ b/app/views/diaries/_form.html.haml
@@ -1,7 +1,9 @@
 = simple_form_for diary do |f|
   = f.error_notification
   .vstack.gap-3
-    = f.input :recorded_on, as: :date, input_html: { value: diary.recorded_on || Date.current }
+    .mb-3
+      %label.form-label 日付
+      %p.form-control-plaintext= l(diary.recorded_on || Date.current, format: :default)
     = f.input :title
     = f.input :body, as: :text, input_html: { rows: 8 }
     = f.input :mood, as: :select, collection: (1..5).map { |i| [i, i] }, include_blank: false

--- a/spec/models/diary_spec.rb
+++ b/spec/models/diary_spec.rb
@@ -59,6 +59,34 @@ RSpec.describe Diary, type: :model do
       it "recorded_onがあれば有効" do
         expect(build(:diary, recorded_on: Date.current)).to be_valid
       end
+
+      context "on: :create" do
+        it "当日なら有効" do
+          expect(build(:diary, recorded_on: Date.current)).to be_valid
+        end
+
+        it "昨日なら無効" do
+          expect(build(:diary, recorded_on: Date.yesterday)).not_to be_valid
+        end
+
+        it "翌日なら無効" do
+          expect(build(:diary, recorded_on: Date.tomorrow)).not_to be_valid
+        end
+      end
+
+      context "on: :update" do
+        let!(:diary) { create(:diary, recorded_on: Date.current) }
+
+        it "recorded_onを変更すると無効" do
+          diary.recorded_on = Date.yesterday
+          expect(diary).not_to be_valid
+        end
+
+        it "recorded_on以外を変更しても有効" do
+          diary.title = "新しいタイトル"
+          expect(diary).to be_valid
+        end
+      end
     end
 
     context "mood" do

--- a/spec/requests/diaries_spec.rb
+++ b/spec/requests/diaries_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Diaries", type: :request do
     before { sign_in user }
 
     let(:valid_params) do
-      { diary: { title: "今日の日記", body: "晴れだった", recorded_on: Date.today, mood: 3 } }
+      { diary: { title: "今日の日記", body: "晴れだった", mood: 3 } }
     end
 
     it "ログインユーザーに紐づくdiaryを作成する" do


### PR DESCRIPTION
## Summary
- 新規作成時は `recorded_on` を当日に固定し、ユーザーが変更できないようにした
- 編集時は `recorded_on` を変更不可にした（フォームは表示専用、Strong Parameters でも除外）
- モデルバリデーション（`on: :create` / `on: :update`）でサーバー側の多層防御を実装

## Test plan
- [ ] `bundle exec rspec spec/models/diary_spec.rb` — 当日/昨日/翌日 × create、変更あり/なし × update のバリデーション
- [ ] `bundle exec rspec spec/requests/diaries_spec.rb` — `recorded_on` 改ざん送信でも保存値が変わらないこと
- [ ] 新規作成フォームで日付が表示専用（本日固定）になっていること
- [ ] 編集フォームで日付が表示専用になっていること

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)