### PR TITLE
feat: ジオロケーションで天気取得・日記作成機能を実装

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -79,6 +79,7 @@ class DiariesController < ApplicationController
   def location_params
     lat = params[:latitude].to_f
     lng = params[:longitude].to_f
+    # TODO: ロジックを切り出す
     return nil unless lat.between?(-90, 90) && lng.between?(-180, 180) && (lat != 0.0 || lng != 0.0)
 
     [ lat, lng ]

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -7,7 +7,8 @@ class DiariesController < ApplicationController
     @total_count  = scope.count
     @yearly_count = scope.where(recorded_on: Date.current.all_year).count
 
-    if location_params
+    coords = location_params
+    if coords
       weather    = WeatherService.new(latitude: coords[0], longitude: coords[1]).fetch
       @rainy_now = weather.present? && WeatherRecord.rainy?(weather[:weather_main])
     else
@@ -29,7 +30,8 @@ class DiariesController < ApplicationController
     @diary.recorded_on = Date.current # NOTE: 雨の日以外を選択出来ないように日付は固定
     authorize @diary
 
-    if location_params.nil?
+    coords = location_params
+    if coords.nil?
       flash.now[:alert] = "位置情報を許可してください"
       return render :new, status: :unprocessable_entity
     end
@@ -77,7 +79,6 @@ class DiariesController < ApplicationController
   def location_params
     lat = params[:latitude].to_f
     lng = params[:longitude].to_f
-    # TODO: メソッドに切り出す
     return nil unless lat.between?(-90, 90) && lng.between?(-180, 180) && (lat != 0.0 || lng != 0.0)
 
     [ lat, lng ]

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -7,8 +7,12 @@ class DiariesController < ApplicationController
     @total_count  = scope.count
     @yearly_count = scope.where(recorded_on: Date.current.all_year).count
 
-    weather    = WeatherService.new.fetch
-    @rainy_now = weather.present? && WeatherRecord.rainy?(weather[:weather_main])
+    if location_params
+      weather    = WeatherService.new(latitude: coords[0], longitude: coords[1]).fetch
+      @rainy_now = weather.present? && WeatherRecord.rainy?(weather[:weather_main])
+    else
+      @rainy_now = nil
+    end
   end
 
   def show
@@ -24,8 +28,17 @@ class DiariesController < ApplicationController
     @diary = current_user.diaries.build(diary_params)
     @diary.recorded_on = Date.current # NOTE: 雨の日以外を選択出来ないように日付は固定
     authorize @diary
+
+    if location_params.nil?
+      flash.now[:alert] = "位置情報を許可してください"
+      return render :new, status: :unprocessable_entity
+    end
+
+    latitude  = coords[0]
+    longitude = coords[1]
+
     if @diary.save
-      @diary.attach_weather!
+      @diary.attach_weather!(latitude:, longitude:)
       redirect_to @diary, notice: "日記を作成しました。"
     else
       render :new, status: :unprocessable_entity
@@ -59,5 +72,14 @@ class DiariesController < ApplicationController
 
   def diary_params
     params.require(:diary).permit(:title, :body, :mood)
+  end
+
+  def location_params
+    lat = params[:latitude].to_f
+    lng = params[:longitude].to_f
+    # TODO: メソッドに切り出す
+    return nil unless lat.between?(-90, 90) && lng.between?(-180, 180) && (lat != 0.0 || lng != 0.0)
+
+    [ lat, lng ]
   end
 end

--- a/app/javascript/controllers/geolocation_controller.js
+++ b/app/javascript/controllers/geolocation_controller.js
@@ -1,0 +1,62 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["latitude", "longitude", "submit", "message", "newLink"]
+  static values = { mode: { type: String, default: "form" } }
+
+  connect() {
+    if (!navigator.geolocation) {
+      this.handleError()
+      return
+    }
+    navigator.geolocation.getCurrentPosition(
+      (position) => this.handleSuccess(position),
+      () => this.handleError(),
+      { timeout: 10000 }
+    )
+  }
+
+  handleSuccess(position) {
+    const { latitude, longitude } = position.coords
+    debugger
+
+    if (this.modeValue === "index") {
+      const searchParams = new URLSearchParams(window.location.search)
+      if (!searchParams.has("latitude") && !searchParams.has("longitude")) {
+        const url = new URL(window.location.href)
+        url.searchParams.set("latitude", latitude)
+        url.searchParams.set("longitude", longitude)
+        window.location.replace(url.toString())
+        return
+      }
+    }
+
+    if (this.hasLatitudeTarget) {
+      this.latitudeTarget.value = latitude
+    }
+    if (this.hasLongitudeTarget) {
+      this.longitudeTarget.value = longitude
+    }
+    if (this.hasSubmitTarget) {
+      this.submitTarget.disabled = false
+    }
+    if (this.hasMessageTarget) {
+      this.messageTarget.classList.add("d-none")
+    }
+    if (this.hasNewLinkTarget) {
+      this.newLinkTarget.classList.remove("d-none")
+    }
+  }
+
+  handleError() {
+    if (this.hasSubmitTarget) {
+      this.submitTarget.disabled = true
+    }
+    if (this.hasMessageTarget) {
+      this.messageTarget.classList.remove("d-none")
+    }
+    if (this.hasNewLinkTarget) {
+      this.newLinkTarget.classList.add("d-none")
+    }
+  }
+}

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -13,8 +13,8 @@ class Diary < ApplicationRecord
   validate :recorded_on_must_be_today, on: :create
   validate :recorded_on_must_not_change, on: :update
 
-  def attach_weather!
-    weather_data = WeatherService.new.fetch
+  def attach_weather!(latitude:, longitude:)
+    weather_data = WeatherService.new(latitude:, longitude:).fetch
     return if weather_data.blank?
 
     create_weather_record!(weather_data)

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -12,6 +12,7 @@ class Diary < ApplicationRecord
 
   validate :recorded_on_must_be_today, on: :create
   validate :recorded_on_must_not_change, on: :update
+  # TODO: 雨でない場合は日記を保存出来ないバリデーションを追加する
 
   def attach_weather!(latitude:, longitude:)
     weather_data = WeatherService.new(latitude:, longitude:).fetch

--- a/app/services/weather_service.rb
+++ b/app/services/weather_service.rb
@@ -1,21 +1,23 @@
 class WeatherService
-  LATITUDE  = 35.6762
-  LONGITUDE = 139.6503
-  CITY_NAME = "Tokyo"
   BASE_URL  = "https://api.openweathermap.org"
   ENDPOINT  = "/data/2.5/weather"
-  CACHE_KEY = "weather:current"
   CACHE_TTL = 1.hour
 
-  def initialize(api_key: ENV["OPENWEATHER_API_KEY"])
-    @api_key = api_key
+  def initialize(latitude:, longitude:, api_key: ENV["OPENWEATHER_API_KEY"])
+    @latitude  = latitude
+    @longitude = longitude
+    @api_key   = api_key
   end
 
   def fetch
-    Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL, skip_nil: true) { fetch_uncached }
+    Rails.cache.fetch(cache_key, expires_in: CACHE_TTL, skip_nil: true) { fetch_uncached }
   end
 
   private
+
+  def cache_key
+    "weather:current:#{@latitude.to_f.round(2)}:#{@longitude.to_f.round(2)}"
+  end
 
   def fetch_uncached
     return nil if @api_key.blank?
@@ -24,8 +26,8 @@ class WeatherService
 
     response = build_connection.get(ENDPOINT) do |req|
       req.params.merge!(
-        lat:   LATITUDE,
-        lon:   LONGITUDE,
+        lat:   @latitude,
+        lon:   @longitude,
         units: "metric",
         lang:  "ja",
         appid: @api_key
@@ -50,7 +52,7 @@ class WeatherService
     weather = body.dig("weather", 0) || {}
     main    = body["main"] || {}
     {
-      city_name:    body["name"] || CITY_NAME,
+      city_name:    body["name"],
       weather_main: weather["main"],
       description:  weather["description"],
       temp:         main["temp"],

--- a/app/views/diaries/_form.html.haml
+++ b/app/views/diaries/_form.html.haml
@@ -1,5 +1,10 @@
 = simple_form_for diary do |f|
   = f.error_notification
+  - if local_assigns[:geolocation]
+    %input{ type: "hidden", name: "latitude", data: { geolocation_target: "latitude" } }
+    %input{ type: "hidden", name: "longitude", data: { geolocation_target: "longitude" } }
+    .alert.alert-warning{ data: { geolocation_target: "message" } }
+      位置情報の取得を許可してください。ブラウザのアドレスバー横のアイコンから許可できます。
   .vstack.gap-3
     .mb-3
       %label.form-label 日付
@@ -7,4 +12,6 @@
     = f.input :title
     = f.input :body, as: :text, input_html: { rows: 8 }
     = f.input :mood, as: :select, collection: (1..5).map { |i| [i, i] }, include_blank: false
-    = f.button :submit, "保存", class: "btn btn-primary"
+    = f.button :submit, "保存", class: "btn btn-primary",
+        disabled: local_assigns[:geolocation] ? true : false,
+        data: (local_assigns[:geolocation] ? { geolocation_target: "submit" } : {})

--- a/app/views/diaries/index.html.haml
+++ b/app/views/diaries/index.html.haml
@@ -1,29 +1,34 @@
-- if @rainy_now
-  .alert.alert-info.d-flex.align-items-center.gap-3
-    %i.bi.bi-cloud-rain-fill.fs-4
-    %div
-      %strong 今日は雨です
-      = link_to "今日の雨を記録する", new_diary_path, class: "btn btn-primary btn-sm ms-3"
-- else
-  .text-muted.mb-3
-    %i.bi.bi-sun
-    今日は雨ではありません
+.container{ data: { controller: "geolocation", geolocation_mode_value: "index" } }
+  - if @rainy_now.nil?
+    .alert.alert-info{ data: { geolocation_target: "message" } }
+      天気を確認するには位置情報を許可してください。
+  - elsif @rainy_now
+    .alert.alert-info.d-flex.align-items-center.gap-3
+      %i.bi.bi-cloud-rain-fill.fs-4
+      %div
+        %strong 今日は雨です
+        = link_to "今日の雨を記録する", new_diary_path, class: "btn btn-primary btn-sm ms-3 d-none",
+            data: { geolocation_target: "newLink" }
+  - else
+    .text-muted.mb-3
+      %i.bi.bi-sun
+      今日は雨ではありません
 
-.row.g-3.mb-4
-  .col-md-6
-    .card.text-center.shadow-sm.border-0
-      .card-body
-        %h5.card-title.text-muted 総記録数
-        %p.display-6= @total_count
-  .col-md-6
-    .card.text-center.shadow-sm.border-0
-      .card-body
-        %h5.card-title.text-muted 今年の記録
-        %p.display-6= @yearly_count
+  .row.g-3.mb-4
+    .col-md-6
+      .card.text-center.shadow-sm.border-0
+        .card-body
+          %h5.card-title.text-muted 総記録数
+          %p.display-6= @total_count
+    .col-md-6
+      .card.text-center.shadow-sm.border-0
+        .card-body
+          %h5.card-title.text-muted 今年の記録
+          %p.display-6= @yearly_count
 
-.row.row-cols-1.row-cols-md-2.g-3
-  - @diaries.each do |diary|
-    .col
-      = render "diary_card", diary: diary
+  .row.row-cols-1.row-cols-md-2.g-3
+    - @diaries.each do |diary|
+      .col
+        = render "diary_card", diary: diary
 
-= paginate @diaries
+  = paginate @diaries

--- a/app/views/diaries/new.html.haml
+++ b/app/views/diaries/new.html.haml
@@ -1,3 +1,3 @@
-.container
+.container{ data: { controller: "geolocation" } }
   = render "shared/back_button"
-  = render "form", diary: @diary
+  = render "form", diary: @diary, geolocation: true

--- a/spec/models/diary_spec.rb
+++ b/spec/models/diary_spec.rb
@@ -144,11 +144,11 @@ RSpec.describe Diary, type: :model do
       end
 
       it "weather_record が作成される" do
-        expect { diary.attach_weather! }.to change { WeatherRecord.count }.by(1)
+        expect { diary.attach_weather!(latitude: 35.68, longitude: 139.65) }.to change { WeatherRecord.count }.by(1)
       end
 
       it "weather_record のカラムに正しい値が設定される" do
-        diary.attach_weather!
+        diary.attach_weather!(latitude: 35.68, longitude: 139.65)
         expect(diary.weather_record.city_name).to eq("Tokyo")
         expect(diary.weather_record.weather_main).to eq("Rain")
       end
@@ -160,7 +160,7 @@ RSpec.describe Diary, type: :model do
       end
 
       it "weather_record が作成されない" do
-        expect { diary.attach_weather! }.not_to change { WeatherRecord.count }
+        expect { diary.attach_weather!(latitude: 35.68, longitude: 139.65) }.not_to change { WeatherRecord.count }
       end
     end
 
@@ -170,7 +170,7 @@ RSpec.describe Diary, type: :model do
       end
 
       it "weather_record が作成されない" do
-        expect { diary.attach_weather! }.not_to change { WeatherRecord.count }
+        expect { diary.attach_weather!(latitude: 35.68, longitude: 139.65) }.not_to change { WeatherRecord.count }
       end
     end
   end

--- a/spec/requests/diaries_spec.rb
+++ b/spec/requests/diaries_spec.rb
@@ -19,7 +19,28 @@ RSpec.describe "Diaries", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      context "WeatherService が Rain を返すとき" do
+      context "lat/lng クエリなし" do
+        it "位置情報許可案内が表示される" do
+          get diaries_path
+          expect(response.body).to include("位置情報を許可してください")
+        end
+      end
+
+      context "lat/lng が範囲外の値の場合" do
+        it "位置情報許可案内が表示される（無効な座標は nil 扱い）" do
+          get diaries_path, params: { latitude: 999, longitude: 999 }
+          expect(response.body).to include("位置情報を許可してください")
+        end
+      end
+
+      context "lat/lng が 0, 0（無効扱い）の場合" do
+        it "位置情報許可案内が表示される" do
+          get diaries_path, params: { latitude: 0, longitude: 0 }
+          expect(response.body).to include("位置情報を許可してください")
+        end
+      end
+
+      context "lat/lng クエリあり・WeatherService が Rain を返すとき" do
         before do
           allow_any_instance_of(WeatherService).to receive(:fetch).and_return(
             { weather_main: "Rain", city_name: "Tokyo", description: "雨", temp: 15.0, humidity: 80, rainfall_mm: 3.0 }
@@ -27,12 +48,12 @@ RSpec.describe "Diaries", type: :request do
         end
 
         it "今日の雨を記録するリンクが表示される" do
-          get diaries_path
+          get diaries_path, params: { latitude: 35.68, longitude: 139.65 }
           expect(response.body).to include("今日の雨を記録する")
         end
       end
 
-      context "WeatherService が Clear を返すとき" do
+      context "lat/lng クエリあり・WeatherService が Clear を返すとき" do
         before do
           allow_any_instance_of(WeatherService).to receive(:fetch).and_return(
             { weather_main: "Clear", city_name: "Tokyo", description: "晴れ", temp: 25.0, humidity: 50, rainfall_mm: 0.0 }
@@ -40,16 +61,16 @@ RSpec.describe "Diaries", type: :request do
         end
 
         it "今日は雨ではありませんが表示される" do
-          get diaries_path
+          get diaries_path, params: { latitude: 35.68, longitude: 139.65 }
           expect(response.body).to include("今日は雨ではありません")
         end
       end
 
-      context "WeatherService が nil を返すとき" do
+      context "lat/lng クエリあり・WeatherService が nil を返すとき" do
         before { allow_any_instance_of(WeatherService).to receive(:fetch).and_return(nil) }
 
         it "雨でない表示になる" do
-          get diaries_path
+          get diaries_path, params: { latitude: 35.68, longitude: 139.65 }
           expect(response.body).to include("今日は雨ではありません")
         end
       end
@@ -86,7 +107,7 @@ RSpec.describe "Diaries", type: :request do
     before { sign_in user }
 
     let(:valid_params) do
-      { diary: { title: "今日の日記", body: "晴れだった", mood: 3 } }
+      { diary: { title: "今日の日記", body: "晴れだった", mood: 3 }, latitude: 35.68, longitude: 139.65 }
     end
 
     it "ログインユーザーに紐づくdiaryを作成する" do
@@ -125,6 +146,62 @@ RSpec.describe "Diaries", type: :request do
           post diaries_path, params: valid_params
         }.to change(user.diaries, :count).by(1)
         expect(WeatherRecord.count).to eq(0)
+      end
+    end
+
+    context "latitude / longitude が欠落している場合" do
+      let(:params_without_location) do
+        { diary: { title: "今日の日記", body: "晴れだった", mood: 3 } }
+      end
+
+      it "422 Unprocessable Entity を返す" do
+        post diaries_path, params: params_without_location
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "日記が作成されない" do
+        expect {
+          post diaries_path, params: params_without_location
+        }.not_to change(user.diaries, :count)
+      end
+
+      it "位置情報エラーメッセージが表示される" do
+        post diaries_path, params: params_without_location
+        expect(response.body).to include("位置情報を許可してください")
+      end
+    end
+
+    context "latitude / longitude が無効な値（0, 0）の場合" do
+      let(:invalid_location_params) do
+        { diary: { title: "今日の日記", body: "晴れだった", mood: 3 }, latitude: 0, longitude: 0 }
+      end
+
+      it "422 Unprocessable Entity を返す" do
+        post diaries_path, params: invalid_location_params
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "日記が作成されない" do
+        expect {
+          post diaries_path, params: invalid_location_params
+        }.not_to change(user.diaries, :count)
+      end
+    end
+
+    context "latitude / longitude が範囲外の値の場合" do
+      let(:out_of_range_params) do
+        { diary: { title: "今日の日記", body: "晴れだった", mood: 3 }, latitude: 999, longitude: 999 }
+      end
+
+      it "422 Unprocessable Entity を返す" do
+        post diaries_path, params: out_of_range_params
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "日記が作成されない" do
+        expect {
+          post diaries_path, params: out_of_range_params
+        }.not_to change(user.diaries, :count)
       end
     end
   end

--- a/spec/services/weather_service_spec.rb
+++ b/spec/services/weather_service_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe WeatherService do
   let(:api_key) { "test_api_key" }
-  let(:service) { described_class.new(api_key: api_key) }
+  let(:service) { described_class.new(latitude: 35.68, longitude: 139.65, api_key: api_key) }
 
   let(:success_body_with_rain) do
     {
@@ -76,7 +76,7 @@ RSpec.describe WeatherService do
     end
 
     context "APIキーが nil の場合" do
-      let(:service) { described_class.new(api_key: nil) }
+      let(:service) { described_class.new(latitude: 35.68, longitude: 139.65, api_key: nil) }
 
       it "nil を返し HTTP リクエストを発生させない" do
         expect(service).not_to receive(:build_connection)
@@ -85,7 +85,7 @@ RSpec.describe WeatherService do
     end
 
     context "APIキーが空文字の場合" do
-      let(:service) { described_class.new(api_key: "") }
+      let(:service) { described_class.new(latitude: 35.68, longitude: 139.65, api_key: "") }
 
       it "nil を返し HTTP リクエストを発生させない" do
         expect(service).not_to receive(:build_connection)
@@ -187,6 +187,22 @@ RSpec.describe WeatherService do
       travel_to(WeatherService::CACHE_TTL.from_now + 1.second) do
         service.fetch
       end
+
+      expect(count[:n]).to eq(2)
+    end
+
+    it "異なる緯度経度では別々にキャッシュされる" do
+      count = { n: 0 }
+      conn = counting_connection(count, status: 200, body: success_body_with_rain)
+
+      service_a = described_class.new(latitude: 35.68, longitude: 139.65, api_key: api_key)
+      service_b = described_class.new(latitude: 34.69, longitude: 135.50, api_key: api_key)
+
+      allow(service_a).to receive(:build_connection).and_return(conn)
+      allow(service_b).to receive(:build_connection).and_return(conn)
+
+      service_a.fetch
+      service_b.fetch
 
       expect(count[:n]).to eq(2)
     end


### PR DESCRIPTION
## Summary

- Stimulus の `geolocation` コントローラーを追加し、ブラウザの位置情報を取得してフォームの hidden フィールドへセット
- `index` ページで位置情報が未取得の場合はメッセージを表示し、雨の場合のみ「記録する」リンクを表示
- `new` ページで位置情報が取得されるまで保存ボタンを無効化し、取得後に有効化

## Test plan

- [ ] `bundle exec rspec spec/controllers/diaries_controller_spec.rb`
- [ ] `bundle exec rspec spec/models/diary_spec.rb`
- [ ] ブラウザで位置情報を許可→拒否それぞれの挙動を確認

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)