### PR TITLE
refactor: geolocation_controllerをシンプル化し不要なtarget・handleErrorを削除

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -37,7 +37,11 @@
       "Bash(ruby --version)",
       "Bash(gem list *)",
       "Bash(rtk *)",
-      "Bash(gh api *)"
+      "Bash(gh api *)",
+      "Bash(env)",
+      "Bash(/Users/kokuboriki/.rbenv/shims/bundle exec *)",
+      "Bash(/Users/kokuboriki/dev/rain_diary/.claude/worktrees/agent-a03940843826d9f3b/bin/rubocop *)",
+      "Bash(/bin/zsh *)"
     ]
   }
 }

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -31,7 +31,7 @@ class DiariesController < ApplicationController
     @diary.recorded_on = Date.current # NOTE: 雨の日以外を選択出来ないように日付は固定
     authorize @diary
 
-    # TODO: 早期リターン周りをpriavteに隠蔽しても良いかも
+    # TODO: 早期リターン周りをprivateに隠蔽しても良いかも
     coords = location_params
     if coords.nil?
       flash.now[:alert] = "位置情報を許可してください"

--- a/app/javascript/controllers/geolocation_controller.js
+++ b/app/javascript/controllers/geolocation_controller.js
@@ -1,62 +1,36 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["latitude", "longitude", "submit", "message", "newLink"]
-  static values = { mode: { type: String, default: "form" } }
+  static targets = ["latitude", "longitude"];
 
   connect() {
     if (!navigator.geolocation) {
-      this.handleError()
-      return
+      return;
     }
     navigator.geolocation.getCurrentPosition(
       (position) => this.handleSuccess(position),
-      () => this.handleError(),
+      () => {}, // 座標未取得はサーバー側バリデーションで弾く
       { timeout: 10000 }
-    )
+    );
   }
 
   handleSuccess(position) {
-    const { latitude, longitude } = position.coords
-    debugger
+    const { latitude, longitude } = position.coords;
 
-    if (this.modeValue === "index") {
-      const searchParams = new URLSearchParams(window.location.search)
-      if (!searchParams.has("latitude") && !searchParams.has("longitude")) {
-        const url = new URL(window.location.href)
-        url.searchParams.set("latitude", latitude)
-        url.searchParams.set("longitude", longitude)
-        window.location.replace(url.toString())
-        return
-      }
+    // diary#new
+    if (this.hasLatitudeTarget && this.hasLongitudeTarget) {
+      this.latitudeTarget.value = latitude;
+      this.longitudeTarget.value = longitude;
+      return;
     }
 
-    if (this.hasLatitudeTarget) {
-      this.latitudeTarget.value = latitude
+    // diary#index
+    const url = new URL(window.location.href);
+    if (url.searchParams.has("latitude") && url.searchParams.has("longitude")) {
+      return;
     }
-    if (this.hasLongitudeTarget) {
-      this.longitudeTarget.value = longitude
-    }
-    if (this.hasSubmitTarget) {
-      this.submitTarget.disabled = false
-    }
-    if (this.hasMessageTarget) {
-      this.messageTarget.classList.add("d-none")
-    }
-    if (this.hasNewLinkTarget) {
-      this.newLinkTarget.classList.remove("d-none")
-    }
-  }
-
-  handleError() {
-    if (this.hasSubmitTarget) {
-      this.submitTarget.disabled = true
-    }
-    if (this.hasMessageTarget) {
-      this.messageTarget.classList.remove("d-none")
-    }
-    if (this.hasNewLinkTarget) {
-      this.newLinkTarget.classList.add("d-none")
-    }
+    url.searchParams.set("latitude", latitude);
+    url.searchParams.set("longitude", longitude);
+    window.location.replace(url.toString());
   }
 }

--- a/app/views/diaries/_form.html.haml
+++ b/app/views/diaries/_form.html.haml
@@ -7,8 +7,6 @@
   - if local_assigns[:geolocation]
     %input{ type: "hidden", name: "latitude", data: { geolocation_target: "latitude" } }
     %input{ type: "hidden", name: "longitude", data: { geolocation_target: "longitude" } }
-    .alert.alert-warning{ data: { geolocation_target: "message" } }
-      位置情報の取得を許可してください。ブラウザのアドレスバー横のアイコンから許可できます。
   .vstack.gap-3
     .mb-3
       %label.form-label 日付
@@ -16,6 +14,4 @@
     = f.input :title
     = f.input :body, as: :text, input_html: { rows: 8 }
     = f.input :mood, as: :select, collection: (1..5).map { |i| [i, i] }, include_blank: false
-    = f.button :submit, "保存", class: "btn btn-primary",
-        disabled: local_assigns[:geolocation] ? true : false,
-        data: (local_assigns[:geolocation] ? { geolocation_target: "submit" } : {})
+    = f.button :submit, "保存", class: "btn btn-primary"

--- a/app/views/diaries/index.html.haml
+++ b/app/views/diaries/index.html.haml
@@ -1,14 +1,13 @@
-.container{ data: { controller: "geolocation", geolocation_mode_value: "index" } }
+.container{ data: { controller: "geolocation" } }
   - if @rainy_now.nil?
-    .alert.alert-info{ data: { geolocation_target: "message" } }
+    .alert.alert-info
       天気を確認するには位置情報を許可してください。
   - elsif @rainy_now
     .alert.alert-info.d-flex.align-items-center.gap-3
       %i.bi.bi-cloud-rain-fill.fs-4
       %div
         %strong 今日は雨です
-        = link_to "今日の雨を記録する", new_diary_path, class: "btn btn-primary btn-sm ms-3 d-none",
-            data: { geolocation_target: "newLink" }
+        = link_to "今日の雨を記録する", new_diary_path, class: "btn btn-primary btn-sm ms-3"
   - else
     .text-muted.mb-3
       %i.bi.bi-sun


### PR DESCRIPTION
## Summary

- `mode` 値と index/form の分岐を廃止し、target の有無で動作を切り替える形に統一
- `handleError` / `submit` / `message` / `newLink` target を削除し、エラー処理をサーバー側バリデーションに委譲
- フォームの送信ボタンの `disabled` 制御とアラートメッセージをビューから削除し、コードを簡潔化

## Test plan

- [ ] `bundle exec rspec` がすべてパスすること
- [ ] ブラウザで位置情報を許可した場合に diary#new / diary#index が正常に動作すること
- [ ] 位置情報を拒否した場合にサーバー側バリデーションでエラーが表示されること

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified geolocation handling in diary creation—removed location permission warnings.
  * Diary form submit button is now always enabled.
  * "Today's rain" button displays automatically when rainfall is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->