### PR TITLE
WeatherService#fetch を fetch! に変更し例外ベース設計に移行

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,7 +1,7 @@
 class DiariesController < ApplicationController
   before_action :set_diary, only: %i[show edit update destroy]
 
-  # TODO: 各アクションの処理をリファクタリングする
+  # TODO: 行数が長いアクションに関してリファクタしたい
   def index
     authorize Diary
     scope = policy_scope(Diary)
@@ -14,14 +14,15 @@ class DiariesController < ApplicationController
       @rainy_now = nil
       @location_missing = true
     else
-      weather_data = WeatherService.new(latitude: coords[0], longitude: coords[1]).fetch
-      if weather_api_error?(weather_data)
-        flash.now[:alert] = weather_alert_for(weather_data)
-        @rainy_now = nil
-      else
-        @rainy_now = weather_data.present? && WeatherRecord.rainy?(weather_data[:weather_main])
-      end
+      weather_data = WeatherService.new(latitude: coords[0], longitude: coords[1]).fetch!
+      @rainy_now = WeatherRecord.rainy?(weather_data[:weather_main])
     end
+  rescue WeatherService::RateLimitedError
+    flash.now[:alert] = "天気情報を取得できませんでした。しばらく時間を空けてからお試しください。"
+    @rainy_now = nil
+  rescue WeatherService::Error
+    flash.now[:alert] = "天気情報を取得できませんでした。"
+    @rainy_now = nil
   end
 
   def show
@@ -38,7 +39,6 @@ class DiariesController < ApplicationController
     @diary.recorded_on = Date.current # NOTE: 雨の日以外を選択出来ないように日付は固定
     authorize @diary
 
-    # TODO: 早期リターン周りをprivateに隠蔽しても良いかも
     coords = location_params
     if coords.nil?
       flash.now[:alert] = "位置情報を許可してください"
@@ -46,18 +46,7 @@ class DiariesController < ApplicationController
     end
 
     latitude, longitude = coords
-    weather_data = WeatherService.new(latitude:, longitude:).fetch
-    alert = weather_alert_for(weather_data)
-    if alert
-      flash.now[:alert] = alert
-      return render :new, status: :unprocessable_entity
-    end
-
-    if weather_data.blank?
-      flash.now[:alert] = "現在の天気が取得できませんでした。しばらく経ってからお試しください"
-      return render :new, status: :unprocessable_entity
-    end
-
+    weather_data = WeatherService.new(latitude:, longitude:).fetch!
     @diary.assign_weather(weather_data)
 
     if @diary.save
@@ -65,6 +54,12 @@ class DiariesController < ApplicationController
     else
       render :new, status: :unprocessable_entity
     end
+  rescue WeatherService::RateLimitedError
+    flash.now[:alert] = "天気情報を取得できませんでした。しばらく時間を空けてからお試しください。"
+    render :new, status: :unprocessable_entity
+  rescue WeatherService::Error
+    flash.now[:alert] = "天気情報を取得できませんでした。"
+    render :new, status: :unprocessable_entity
   end
 
   def edit
@@ -94,21 +89,6 @@ class DiariesController < ApplicationController
 
   def diary_params
     params.require(:diary).permit(:title, :body, :mood)
-  end
-
-  def weather_api_error?(result)
-    result.is_a?(Symbol)
-  end
-
-  def weather_alert_for(result)
-    case result
-    when :rate_limited
-      "天気情報を取得できませんでした。しばらく時間を空けてからお試しください。"
-    when :server_error
-      "天気情報を取得できませんでした。時間をおいて再度お試しください。"
-    when Symbol
-      "天気情報を取得できませんでした。"
-    end
   end
 
   def location_params

--- a/app/services/weather_service.rb
+++ b/app/services/weather_service.rb
@@ -47,14 +47,14 @@ class WeatherService
     end
 
     unless response.success?
-      Rails.logger.error("[WeatherService] HTTP error: status=#{response.status}")
-      raise ApiError, "status=#{response.status}"
+      Rails.logger.error("[WeatherService] HTTP error: status=#{response.status} message=#{response.body['message']}")
+      raise ApiError
     end
 
     parse(response.body)
   rescue Faraday::Error => e
-    Rails.logger.error("[WeatherService] Faraday error: #{e.class}")
-    raise ApiError, "#{e.class}: #{e.message}"
+    Rails.logger.error("[WeatherService] Faraday error: #{e.class}: #{e.message}")
+    raise ApiError
   end
 
   def build_connection

--- a/app/services/weather_service.rb
+++ b/app/services/weather_service.rb
@@ -3,18 +3,22 @@ class WeatherService
   ENDPOINT  = "/data/2.5/weather"
   CACHE_TTL = 1.hour
 
+  class Error < StandardError; end
+  class RateLimitedError < Error; end
+  class ApiError < Error; end
+
   def initialize(latitude:, longitude:, api_key: ENV["OPENWEATHER_API_KEY"])
     @latitude  = latitude
     @longitude = longitude
     @api_key   = api_key
   end
 
-  def fetch
+  def fetch!
     cached = Rails.cache.read(cache_key)
     return cached if cached
 
     result = fetch_uncached
-    Rails.cache.write(cache_key, result, expires_in: CACHE_TTL) if weather_data?(result)
+    Rails.cache.write(cache_key, result, expires_in: CACHE_TTL)
     result
   end
 
@@ -25,8 +29,6 @@ class WeatherService
   end
 
   def fetch_uncached
-    return nil if @api_key.blank?
-
     Rails.logger.debug("[WeatherService] calling API")
 
     response = build_connection.get(ENDPOINT) do |req|
@@ -39,19 +41,20 @@ class WeatherService
       )
     end
 
-    # TODO: 例外設計が適切か思考する。
-    # TODO: 調査できるように必要であればログを残す
-    return :bad_request  if response.status == 400
-    return :unauthorized if response.status == 401
-    return :not_found    if response.status == 404
-    return :rate_limited if response.status == 429
-    return :server_error if response.status.between?(500, 599)
-    return nil unless response.success?
+    if response.status == 429
+      Rails.logger.info("[WeatherService] rate limited")
+      raise RateLimitedError
+    end
+
+    unless response.success?
+      Rails.logger.error("[WeatherService] HTTP error: status=#{response.status}")
+      raise ApiError, "status=#{response.status}"
+    end
 
     parse(response.body)
   rescue Faraday::Error => e
     Rails.logger.error("[WeatherService] Faraday error: #{e.class}")
-    nil
+    raise ApiError, "#{e.class}: #{e.message}"
   end
 
   def build_connection
@@ -72,9 +75,5 @@ class WeatherService
       humidity:     main["humidity"],
       rainfall_mm:  body.dig("rain", "1h").to_f
     }
-  end
-
-  def weather_data?(result)
-    result.is_a?(Hash)
   end
 end

--- a/spec/requests/diaries_spec.rb
+++ b/spec/requests/diaries_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Diaries", type: :request do
 
       context "lat/lng クエリあり・WeatherService が Rain を返すとき" do
         before do
-          allow_any_instance_of(WeatherService).to receive(:fetch).and_return(
+          allow_any_instance_of(WeatherService).to receive(:fetch!).and_return(
             { weather_main: "Rain", city_name: "Tokyo", description: "雨", temp: 15.0, humidity: 80, rainfall_mm: 3.0 }
           )
         end
@@ -55,7 +55,7 @@ RSpec.describe "Diaries", type: :request do
 
       context "lat/lng クエリあり・WeatherService が Clear を返すとき" do
         before do
-          allow_any_instance_of(WeatherService).to receive(:fetch).and_return(
+          allow_any_instance_of(WeatherService).to receive(:fetch!).and_return(
             { weather_main: "Clear", city_name: "Tokyo", description: "晴れ", temp: 25.0, humidity: 50, rainfall_mm: 0.0 }
           )
         end
@@ -66,39 +66,21 @@ RSpec.describe "Diaries", type: :request do
         end
       end
 
-      context "lat/lng クエリあり・WeatherService が nil を返すとき" do
-        before { allow_any_instance_of(WeatherService).to receive(:fetch).and_return(nil) }
+      context "lat/lng クエリあり・WeatherService が ApiError を raise するとき" do
+        before { allow_any_instance_of(WeatherService).to receive(:fetch!).and_raise(WeatherService::ApiError) }
 
-        it "雨でない表示になる" do
+        it "天気取得失敗メッセージが表示される" do
           get diaries_path, params: { latitude: 35.68, longitude: 139.65 }
-          expect(response.body).to include("今日は雨ではありません")
+          expect(response.body).to include("天気情報を取得できませんでした。")
         end
       end
 
-      context "lat/lng クエリあり・WeatherService が :rate_limited を返すとき" do
-        before { allow_any_instance_of(WeatherService).to receive(:fetch).and_return(:rate_limited) }
+      context "lat/lng クエリあり・WeatherService が RateLimitedError を raise するとき" do
+        before { allow_any_instance_of(WeatherService).to receive(:fetch!).and_raise(WeatherService::RateLimitedError) }
 
         it "レート制限エラーメッセージが表示される" do
           get diaries_path, params: { latitude: 35.68, longitude: 139.65 }
           expect(response.body).to include("しばらく時間を空けて")
-        end
-      end
-
-      context "lat/lng クエリあり・WeatherService が :server_error を返すとき" do
-        before { allow_any_instance_of(WeatherService).to receive(:fetch).and_return(:server_error) }
-
-        it "サーバーエラーメッセージが表示される" do
-          get diaries_path, params: { latitude: 35.68, longitude: 139.65 }
-          expect(response.body).to include("時間をおいて")
-        end
-      end
-
-      context "lat/lng クエリあり・WeatherService が :not_found を返すとき" do
-        before { allow_any_instance_of(WeatherService).to receive(:fetch).and_return(:not_found) }
-
-        it "汎用エラーメッセージが表示される" do
-          get diaries_path, params: { latitude: 35.68, longitude: 139.65 }
-          expect(response.body).to include("天気情報を取得できませんでした。")
         end
       end
     end
@@ -137,7 +119,7 @@ RSpec.describe "Diaries", type: :request do
 
     before do
       sign_in user
-      allow_any_instance_of(WeatherService).to receive(:fetch).and_return(
+      allow_any_instance_of(WeatherService).to receive(:fetch!).and_return(
         city_name: "Tokyo", weather_main: "Rain", description: "小雨",
         temp: 14.5, humidity: 82, rainfall_mm: 3.2
       )
@@ -162,9 +144,9 @@ RSpec.describe "Diaries", type: :request do
       end
     end
 
-    context "WeatherService が nil を返す場合" do
+    context "WeatherService が ApiError を raise する場合" do
       before do
-        allow_any_instance_of(WeatherService).to receive(:fetch).and_return(nil)
+        allow_any_instance_of(WeatherService).to receive(:fetch!).and_raise(WeatherService::ApiError)
       end
 
       it "日記が作成されない" do
@@ -180,13 +162,13 @@ RSpec.describe "Diaries", type: :request do
 
       it "天気取得失敗メッセージが表示される" do
         post diaries_path, params: valid_params
-        expect(response.body).to include("現在の天気が取得できませんでした")
+        expect(response.body).to include("天気情報を取得できませんでした。")
       end
     end
 
-    context "WeatherService が :rate_limited を返す場合" do
+    context "WeatherService が RateLimitedError を raise する場合" do
       before do
-        allow_any_instance_of(WeatherService).to receive(:fetch).and_return(:rate_limited)
+        allow_any_instance_of(WeatherService).to receive(:fetch!).and_raise(WeatherService::RateLimitedError)
       end
 
       it "422 を返す" do
@@ -206,53 +188,9 @@ RSpec.describe "Diaries", type: :request do
       end
     end
 
-    context "WeatherService が :server_error を返す場合" do
-      before do
-        allow_any_instance_of(WeatherService).to receive(:fetch).and_return(:server_error)
-      end
-
-      it "422 を返す" do
-        post diaries_path, params: valid_params
-        expect(response).to have_http_status(:unprocessable_entity)
-      end
-
-      it "日記が作成されない" do
-        expect {
-          post diaries_path, params: valid_params
-        }.not_to change(user.diaries, :count)
-      end
-
-      it "サーバーエラーメッセージが表示される" do
-        post diaries_path, params: valid_params
-        expect(response.body).to include("時間をおいて")
-      end
-    end
-
-    context "WeatherService が :not_found を返す場合" do
-      before do
-        allow_any_instance_of(WeatherService).to receive(:fetch).and_return(:not_found)
-      end
-
-      it "422 を返す" do
-        post diaries_path, params: valid_params
-        expect(response).to have_http_status(:unprocessable_entity)
-      end
-
-      it "日記が作成されない" do
-        expect {
-          post diaries_path, params: valid_params
-        }.not_to change(user.diaries, :count)
-      end
-
-      it "汎用エラーメッセージが表示される" do
-        post diaries_path, params: valid_params
-        expect(response.body).to include("天気情報を取得できませんでした。")
-      end
-    end
-
     context "WeatherService が Clear を返す場合" do
       before do
-        allow_any_instance_of(WeatherService).to receive(:fetch).and_return(
+        allow_any_instance_of(WeatherService).to receive(:fetch!).and_return(
           city_name: "Tokyo", weather_main: "Clear", description: "晴れ",
           temp: 25.0, humidity: 50, rainfall_mm: 0.0
         )
@@ -277,7 +215,7 @@ RSpec.describe "Diaries", type: :request do
 
     context "WeatherService が Drizzle を返す場合" do
       before do
-        allow_any_instance_of(WeatherService).to receive(:fetch).and_return(
+        allow_any_instance_of(WeatherService).to receive(:fetch!).and_return(
           city_name: "Tokyo", weather_main: "Drizzle", description: "霧雨",
           temp: 14.0, humidity: 85, rainfall_mm: 1.0
         )

--- a/spec/services/weather_service_spec.rb
+++ b/spec/services/weather_service_spec.rb
@@ -35,33 +35,33 @@ RSpec.describe WeatherService do
     allow(service).to receive(:build_connection).and_return(conn)
   end
 
-  describe "#fetch" do
+  describe "#fetch!" do
     context "雨データがある場合" do
       before { stub_connection(status: 200, body: success_body_with_rain) }
 
       it "city_name が Tokyo を返す" do
-        result = service.fetch
+        result = service.fetch!
         expect(result[:city_name]).to eq("Tokyo")
       end
 
       it "current.temp を返す" do
-        result = service.fetch
+        result = service.fetch!
         expect(result[:temp]).to eq(22.5)
       end
 
       it "rainfall_mm が正の値を返す" do
-        result = service.fetch
+        result = service.fetch!
         expect(result[:rainfall_mm]).to eq(1.2)
       end
 
       it "weather_main と description を返す" do
-        result = service.fetch
+        result = service.fetch!
         expect(result[:weather_main]).to eq("Rain")
         expect(result[:description]).to eq("小雨")
       end
 
       it "humidity を返す" do
-        result = service.fetch
+        result = service.fetch!
         expect(result[:humidity]).to eq(60)
       end
     end
@@ -70,58 +70,45 @@ RSpec.describe WeatherService do
       before { stub_connection(status: 200, body: success_body_without_rain) }
 
       it "rainfall_mm が 0.0 を返す" do
-        result = service.fetch
+        result = service.fetch!
         expect(result[:rainfall_mm]).to eq(0.0)
-      end
-    end
-
-    context "APIキーが nil の場合" do
-      let(:service) { described_class.new(latitude: 35.68, longitude: 139.65, api_key: nil) }
-
-      it "nil を返し HTTP リクエストを発生させない" do
-        expect(service).not_to receive(:build_connection)
-        expect(service.fetch).to be_nil
-      end
-    end
-
-    context "APIキーが空文字の場合" do
-      let(:service) { described_class.new(latitude: 35.68, longitude: 139.65, api_key: "") }
-
-      it "nil を返し HTTP リクエストを発生させない" do
-        expect(service).not_to receive(:build_connection)
-        expect(service.fetch).to be_nil
       end
     end
 
     context "レスポンスが 400 の場合" do
       before { stub_connection(status: 400, body: { "message" => "bad request" }) }
 
-      it ":bad_request を返す" do
-        expect(service.fetch).to eq(:bad_request)
+      it "ApiError を raise する" do
+        expect { service.fetch! }.to raise_error(WeatherService::ApiError)
       end
     end
 
     context "レスポンスが 401 の場合" do
       before { stub_connection(status: 401, body: { "message" => "unauthorized" }) }
 
-      it ":unauthorized を返す" do
-        expect(service.fetch).to eq(:unauthorized)
+      it "ApiError を raise する" do
+        expect { service.fetch! }.to raise_error(WeatherService::ApiError)
       end
     end
 
     context "レスポンスが 404 の場合" do
       before { stub_connection(status: 404, body: { "message" => "not found" }) }
 
-      it ":not_found を返す" do
-        expect(service.fetch).to eq(:not_found)
+      it "ApiError を raise する" do
+        expect { service.fetch! }.to raise_error(WeatherService::ApiError)
       end
     end
 
     context "レスポンスが 429 の場合" do
       before { stub_connection(status: 429, body: { "message" => "too many requests" }) }
 
-      it ":rate_limited を返す" do
-        expect(service.fetch).to eq(:rate_limited)
+      it "RateLimitedError を raise する" do
+        expect { service.fetch! }.to raise_error(WeatherService::RateLimitedError)
+      end
+
+      it "info ログを記録する" do
+        expect(Rails.logger).to receive(:info).with(/\[WeatherService\]/)
+        expect { service.fetch! }.to raise_error(WeatherService::RateLimitedError)
       end
     end
 
@@ -130,8 +117,8 @@ RSpec.describe WeatherService do
         context "#{status} のとき" do
           before { stub_connection(status: status, body: { "message" => "server error" }) }
 
-          it ":server_error を返す" do
-            expect(service.fetch).to eq(:server_error)
+          it "ApiError を raise する" do
+            expect { service.fetch! }.to raise_error(WeatherService::ApiError)
           end
         end
       end
@@ -144,26 +131,26 @@ RSpec.describe WeatherService do
         )
       end
 
-      it "nil を返す" do
-        expect(service.fetch).to be_nil
+      it "ApiError を raise する" do
+        expect { service.fetch! }.to raise_error(WeatherService::ApiError)
       end
 
       it "エラーをログに記録する" do
         expect(Rails.logger).to receive(:error).with(/\[WeatherService\]/)
-        service.fetch
+        expect { service.fetch! }.to raise_error(WeatherService::ApiError)
       end
     end
 
     context "Faraday::TimeoutError が発生した場合" do
-      it "nil を返しエラーをログに記録する" do
+      it "ApiError を raise しエラーをログに記録する" do
         allow(service).to receive(:build_connection).and_raise(Faraday::TimeoutError)
         expect(Rails.logger).to receive(:error).with(/WeatherService/)
-        expect(service.fetch).to be_nil
+        expect { service.fetch! }.to raise_error(WeatherService::ApiError)
       end
     end
   end
 
-  describe "#fetch キャッシュ動作" do
+  describe "#fetch! キャッシュ動作" do
     include ActiveSupport::Testing::TimeHelpers
 
     before do
@@ -184,14 +171,14 @@ RSpec.describe WeatherService do
       conn = counting_connection(count, status: 200, body: success_body_with_rain)
       allow(service).to receive(:build_connection).and_return(conn)
 
-      result1 = service.fetch
-      result2 = service.fetch
+      result1 = service.fetch!
+      result2 = service.fetch!
 
       expect(count[:n]).to eq(1)
       expect(result1).to eq(result2)
     end
 
-    it "失敗(:server_error)はキャッシュされず次回呼び出しで再試行する" do
+    it "ApiError はキャッシュされず次回呼び出しで再試行する" do
       stubs_500 = Faraday::Adapter::Test::Stubs.new
       stubs_500.get(WeatherService::ENDPOINT) { [ 500, { "Content-Type" => "application/json" }, {} ] }
       conn500 = Faraday.new(url: WeatherService::BASE_URL) { |f| f.response :json; f.adapter :test, stubs_500 }
@@ -202,11 +189,11 @@ RSpec.describe WeatherService do
 
       allow(service).to receive(:build_connection).and_return(conn500, conn200)
 
-      expect(service.fetch).to eq(:server_error)
-      expect(service.fetch).to be_a(Hash)
+      expect { service.fetch! }.to raise_error(WeatherService::ApiError)
+      expect(service.fetch!).to be_a(Hash)
     end
 
-    it ":rate_limited はキャッシュされず次回呼び出しで再試行する" do
+    it "RateLimitedError はキャッシュされず次回呼び出しで再試行する" do
       stubs_429 = Faraday::Adapter::Test::Stubs.new
       stubs_429.get(WeatherService::ENDPOINT) { [ 429, { "Content-Type" => "application/json" }, {} ] }
       conn429 = Faraday.new(url: WeatherService::BASE_URL) { |f| f.response :json; f.adapter :test, stubs_429 }
@@ -217,8 +204,8 @@ RSpec.describe WeatherService do
 
       allow(service).to receive(:build_connection).and_return(conn429, conn200)
 
-      expect(service.fetch).to eq(:rate_limited)
-      expect(service.fetch).to be_a(Hash)
+      expect { service.fetch! }.to raise_error(WeatherService::RateLimitedError)
+      expect(service.fetch!).to be_a(Hash)
     end
 
     it "TTL 経過後は API を再呼び出しする" do
@@ -226,9 +213,9 @@ RSpec.describe WeatherService do
       conn = counting_connection(count, status: 200, body: success_body_with_rain)
       allow(service).to receive(:build_connection).and_return(conn)
 
-      service.fetch
+      service.fetch!
       travel_to(WeatherService::CACHE_TTL.from_now + 1.second) do
-        service.fetch
+        service.fetch!
       end
 
       expect(count[:n]).to eq(2)
@@ -244,8 +231,8 @@ RSpec.describe WeatherService do
       allow(service_a).to receive(:build_connection).and_return(conn)
       allow(service_b).to receive(:build_connection).and_return(conn)
 
-      service_a.fetch
-      service_b.fetch
+      service_a.fetch!
+      service_b.fetch!
 
       expect(count[:n]).to eq(2)
     end


### PR DESCRIPTION
## Summary

- `WeatherService#fetch` を `fetch!` に改名し、エラー時にシンボル返却ではなく例外（`RateLimitedError` / `ApiError`）を raise するよう変更
- コントローラー側で `rescue` による明示的なエラーハンドリングに統一し、`weather_api_error?` / `weather_alert_for` ヘルパーを削除
- テストを新しい例外設計に合わせて更新

## Test plan

- [ ] `bundle exec rspec spec/services/weather_service_spec.rb`
- [ ] `bundle exec rspec spec/requests/diaries_spec.rb`

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust weather error handling: API failures and rate limits now surface predictable outcomes and user alerts instead of silent/ambiguous results.
  * Caching tightened so successful data is cached but error responses are not cached.

* **Refactor**
  * Simplified weather-related flow in diary listing and creation for clearer behavior.

* **Tests**
  * Test suite updated to reflect new error and caching behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/riki0303/rain_diary/pull/56)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->