### PR TITLE
refactor: location_params のバリデーションを valid_coordinates? に切り出す

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -94,9 +94,12 @@ class DiariesController < ApplicationController
   def location_params
     lat = params[:latitude].to_f
     lng = params[:longitude].to_f
-    # TODO: ロジックを切り出す
-    return nil unless lat.between?(-90, 90) && lng.between?(-180, 180) && (lat != 0.0 || lng != 0.0)
+    return nil unless valid_coordinates?(lat, lng)
 
     [ lat, lng ]
+  end
+
+  def valid_coordinates?(lat, lng)
+    lat.between?(-90, 90) && lng.between?(-180, 180) && (lat != 0.0 || lng != 0.0)
   end
 end

--- a/spec/requests/diaries_spec.rb
+++ b/spec/requests/diaries_spec.rb
@@ -265,6 +265,11 @@ RSpec.describe "Diaries", type: :request do
           post diaries_path, params: invalid_location_params
         }.not_to change(user.diaries, :count)
       end
+
+      it "位置情報エラーメッセージが表示される" do
+        post diaries_path, params: invalid_location_params
+        expect(response.body).to include("位置情報を許可してください")
+      end
     end
 
     context "latitude / longitude が範囲外の値の場合" do
@@ -281,6 +286,11 @@ RSpec.describe "Diaries", type: :request do
         expect {
           post diaries_path, params: out_of_range_params
         }.not_to change(user.diaries, :count)
+      end
+
+      it "位置情報エラーメッセージが表示される" do
+        post diaries_path, params: out_of_range_params
+        expect(response.body).to include("位置情報を許可してください")
       end
     end
   end


### PR DESCRIPTION
## Summary

- `DiariesController#location_params` から座標バリデーション条件を `valid_coordinates?(lat, lng)` という private メソッドに分離
- TODO コメント（`# TODO: ロジックを切り出す`）を削除
- POST 経路の request spec に `(0,0)` および範囲外値のエラーメッセージ確認を追加（GET 側と対称）

## Test plan

- [ ] `bundle exec rspec spec/requests/diaries_spec.rb` — 41 examples, 0 failures
- [ ] `bundle exec rubocop app/controllers/diaries_controller.rb` — no offenses
- [ ] `bundle exec brakeman -q` — No warnings found
- [ ] `bundle exec rails_best_practices .` — No warning found

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)